### PR TITLE
Validate and bound the in-memory cache TTL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Set GCP credentials in `.env.local`, then open [http://localhost:3000](http://lo
 | --- | --- |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to service account JSON |
 | `GCP_SERVICE_ACCOUNT_KEY` | Base64-encoded service account JSON |
-| `CACHE_TTL_SECONDS` | Cache TTL in seconds. Default: 900 |
+| `CACHE_TTL_SECONDS` | Cache TTL in seconds. Supported range: 1–86,400. Default: 900 (invalid, negative, zero, or over-limit values fall back to default) |
 
 Setup guide: [Hubble BigQuery connection](https://developers.stellar.org/docs/data/analytics/hubble/developer-guide/connecting-to-bigquery).
 

--- a/lib/hubble/cache.test.ts
+++ b/lib/hubble/cache.test.ts
@@ -1,0 +1,108 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseCacheTtl,
+  setCache,
+  getCached,
+  clearCache,
+  DEFAULT_CACHE_TTL_SECONDS,
+  MIN_CACHE_TTL_SECONDS,
+  MAX_CACHE_TTL_SECONDS,
+} from "./cache.ts";
+
+describe("parseCacheTtl", () => {
+  test("missing or empty configuration uses default TTL (900s)", () => {
+    assert.equal(parseCacheTtl(undefined), DEFAULT_CACHE_TTL_SECONDS);
+    assert.equal(parseCacheTtl(null), DEFAULT_CACHE_TTL_SECONDS);
+    assert.equal(parseCacheTtl(""), DEFAULT_CACHE_TTL_SECONDS);
+    assert.equal(parseCacheTtl("   "), DEFAULT_CACHE_TTL_SECONDS);
+  });
+
+  test("valid numeric and string values within [1, 86400] range are accepted", () => {
+    assert.equal(parseCacheTtl(MIN_CACHE_TTL_SECONDS), 1);
+    assert.equal(parseCacheTtl(60), 60);
+    assert.equal(parseCacheTtl("300"), 300);
+    assert.equal(parseCacheTtl(900), 900);
+    assert.equal(parseCacheTtl(3600), 3600);
+    assert.equal(parseCacheTtl(MAX_CACHE_TTL_SECONDS), 86400);
+    assert.equal(parseCacheTtl("86400"), 86400);
+  });
+
+  test("floats within valid range are floored to whole seconds", () => {
+    assert.equal(parseCacheTtl(300.7), 300);
+    assert.equal(parseCacheTtl("150.9"), 150);
+  });
+
+  test("non-numeric inputs fall back to default TTL", () => {
+    assert.equal(parseCacheTtl("invalid"), DEFAULT_CACHE_TTL_SECONDS);
+    assert.equal(parseCacheTtl("abc"), DEFAULT_CACHE_TTL_SECONDS);
+    assert.equal(parseCacheTtl({}), DEFAULT_CACHE_TTL_SECONDS);
+    assert.equal(parseCacheTtl([]), DEFAULT_CACHE_TTL_SECONDS);
+  });
+
+  test("non-finite inputs (NaN, Infinity, -Infinity) fall back to default TTL", () => {
+    assert.equal(parseCacheTtl(NaN), DEFAULT_CACHE_TTL_SECONDS);
+    assert.equal(parseCacheTtl(Infinity), DEFAULT_CACHE_TTL_SECONDS);
+    assert.equal(parseCacheTtl(-Infinity), DEFAULT_CACHE_TTL_SECONDS);
+  });
+
+  test("zero falls back to default TTL", () => {
+    assert.equal(parseCacheTtl(0), DEFAULT_CACHE_TTL_SECONDS);
+    assert.equal(parseCacheTtl("0"), DEFAULT_CACHE_TTL_SECONDS);
+  });
+
+  test("negative values fall back to default TTL", () => {
+    assert.equal(parseCacheTtl(-1), DEFAULT_CACHE_TTL_SECONDS);
+    assert.equal(parseCacheTtl(-900), DEFAULT_CACHE_TTL_SECONDS);
+    assert.equal(parseCacheTtl("-60"), DEFAULT_CACHE_TTL_SECONDS);
+  });
+
+  test("over-limit values (> 86400) fall back to default TTL", () => {
+    assert.equal(parseCacheTtl(MAX_CACHE_TTL_SECONDS + 1), DEFAULT_CACHE_TTL_SECONDS);
+    assert.equal(parseCacheTtl(100_000), DEFAULT_CACHE_TTL_SECONDS);
+    assert.equal(parseCacheTtl("9999999"), DEFAULT_CACHE_TTL_SECONDS);
+  });
+});
+
+describe("in-memory cache behavior", () => {
+  beforeEach(() => {
+    clearCache();
+  });
+
+  test("setCache and getCached store and retrieve data with valid TTL", () => {
+    setCache("testKey", { foo: "bar" }, 60);
+    const cached = getCached<{ foo: string }>("testKey");
+    assert.deepEqual(cached, { foo: "bar" });
+  });
+
+  test("setCache with invalid TTL parameters safely falls back to default TTL", () => {
+    setCache("invalidTtlKey", "value", -500);
+    assert.equal(getCached<string>("invalidTtlKey"), "value");
+
+    setCache("nanTtlKey", "value2", NaN);
+    assert.equal(getCached<string>("nanTtlKey"), "value2");
+  });
+
+  test("setCache using process.env.CACHE_TTL_SECONDS handles valid and invalid env vars", () => {
+    const originalEnv = process.env.CACHE_TTL_SECONDS;
+    try {
+      process.env.CACHE_TTL_SECONDS = "600";
+      setCache("envValid", "data1");
+      assert.equal(getCached<string>("envValid"), "data1");
+
+      process.env.CACHE_TTL_SECONDS = "-999";
+      setCache("envInvalid", "data2");
+      assert.equal(getCached<string>("envInvalid"), "data2");
+
+      delete process.env.CACHE_TTL_SECONDS;
+      setCache("envMissing", "data3");
+      assert.equal(getCached<string>("envMissing"), "data3");
+    } finally {
+      process.env.CACHE_TTL_SECONDS = originalEnv;
+    }
+  });
+
+  test("getCached returns null for non-existent keys", () => {
+    assert.equal(getCached("nonexistent"), null);
+  });
+});

--- a/lib/hubble/cache.ts
+++ b/lib/hubble/cache.ts
@@ -1,4 +1,34 @@
+export const DEFAULT_CACHE_TTL_SECONDS = 900;
+export const MIN_CACHE_TTL_SECONDS = 1;
+export const MAX_CACHE_TTL_SECONDS = 86_400;
+
+export function parseCacheTtl(input?: unknown): number {
+  if (input === undefined || input === null) {
+    return DEFAULT_CACHE_TTL_SECONDS;
+  }
+
+  if (typeof input === "string" && input.trim() === "") {
+    return DEFAULT_CACHE_TTL_SECONDS;
+  }
+
+  const num = typeof input === "number" ? input : Number(input);
+
+  if (!Number.isFinite(num) || Number.isNaN(num)) {
+    return DEFAULT_CACHE_TTL_SECONDS;
+  }
+
+  if (num < MIN_CACHE_TTL_SECONDS || num > MAX_CACHE_TTL_SECONDS) {
+    return DEFAULT_CACHE_TTL_SECONDS;
+  }
+
+  return Math.floor(num);
+}
+
 const cache = new Map<string, { data: unknown; expires: number }>();
+
+export function clearCache(): void {
+  cache.clear();
+}
 
 export function getCached<T>(key: string): T | null {
   const entry = cache.get(key);
@@ -17,10 +47,15 @@ export function getCached<T>(key: string): T | null {
 export function setCache(
   key: string,
   data: unknown,
-  ttlSeconds = Number(process.env.CACHE_TTL_SECONDS ?? 900),
+  ttlSeconds?: unknown,
 ): void {
+  const validTtl = parseCacheTtl(
+    ttlSeconds ?? process.env.CACHE_TTL_SECONDS,
+  );
+
   cache.set(key, {
     data,
-    expires: Date.now() + ttlSeconds * 1000,
+    expires: Date.now() + validTtl * 1000,
   });
 }
+

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "node --test \"lib/**/*.test.ts\"",
     "sync:directory": "node scripts/sync-stellar-directory.mjs",
     "test:hubble": "node scripts/test-hubble-queries.mjs"
   },


### PR DESCRIPTION
##closes #8 

Here is the recommended PR title and description in Markdown:

---

### PR Title
```text
fix(cache): validate and bound in-memory cache TTL configuration (#8)
```

---

### PR Description

```markdown
## Summary

Resolves issue #8 by introducing deterministic parsing, validation, and safe boundaries for the in-memory cache TTL configuration (`CACHE_TTL_SECONDS`).

Previously, `CACHE_TTL_SECONDS` was converted directly with `Number(...)` without validation. Missing, non-numeric, negative, zero, or extreme values could cause invalid expiration timestamps (`NaN`), disable caching entirely, or retain cached data far longer than intended.

## Proposed Changes

### Core Logic & Cache API
- **[cache.ts](file:///c:/Users/cisat/.antigravity-ide/lumenmap/lib/hubble/cache.ts)**:
  - Defined explicit configuration constants:
    - `DEFAULT_CACHE_TTL_SECONDS = 900` (15 minutes)
    - `MIN_CACHE_TTL_SECONDS = 1` (1 second)
    - `MAX_CACHE_TTL_SECONDS = 86_400` (24 hours)
  - Created `parseCacheTtl(input?: unknown): number` to validate string/numeric TTL configuration.
  - Rejects missing, empty (`""`, `"   "`), non-numeric (`"abc"`), non-finite (`NaN`, `Infinity`), zero (`0`), negative (`-1`), and over-limit (`> 86,400`) values, falling back to `DEFAULT_CACHE_TTL_SECONDS`.
  - Floors floating-point values to whole integer seconds.
  - Updated `setCache` to process TTL through `parseCacheTtl`, guaranteeing valid expiration timestamps.
  - Added `clearCache()` helper function to support testing and cache resets.

### Testing & Verification
- **[cache.test.ts](file:///c:/Users/cisat/.antigravity-ide/lumenmap/lib/hubble/cache.test.ts)**:
  - Added 12 unit tests using Node's native test runner (`node:test`) covering:
    - Default fallback on missing or empty input.
    - Valid integer and string TTL values within `[1, 86400]`.
    - Float truncation to whole seconds.
    - Non-numeric strings and object inputs.
    - Non-finite numbers (`NaN`, `Infinity`, `-Infinity`).
    - Zero and negative values.
    - Over-limit inputs (> 86,400s).
    - `setCache` and `getCached` storage and retrieval operations under valid and invalid `process.env.CACHE_TTL_SECONDS` settings.

### Documentation & Package Configuration
- **[README.md](file:///c:/Users/cisat/.antigravity-ide/lumenmap/README.md)**: Updated `CACHE_TTL_SECONDS` environment variable docs with supported ranges and fallback behavior.
- **[package.json](file:///c:/Users/cisat/.antigravity-ide/lumenmap/package.json)**: Added `"test": "node --test \"lib/**/*.test.ts\""` script.

## Verification Results

### Unit Tests Execution
```text
▶ parseCacheTtl
  ✔ missing or empty configuration uses default TTL (900s) (1.1248ms)
  ✔ valid numeric and string values within [1, 86400] range are accepted (0.996ms)
  ✔ floats within valid range are floored to whole seconds (0.16ms)
  ✔ non-numeric inputs fall back to default TTL (0.1328ms)
  ✔ non-finite inputs (NaN, Infinity, -Infinity) fall back to default TTL (0.1156ms)
  ✔ zero falls back to default TTL (0.1076ms)
  ✔ negative values fall back to default TTL (0.0989ms)
  ✔ over-limit values (> 86400) fall back to default TTL (0.1616ms)
✔ parseCacheTtl (4.2497ms)
▶ in-memory cache behavior
  ✔ setCache and getCached store and retrieve data with valid TTL (1.1501ms)
  ✔ setCache with invalid TTL parameters safely falls back to default TTL (0.2067ms)
  ✔ setCache using process.env.CACHE_TTL_SECONDS handles valid and invalid env vars (0.2982ms)
  ✔ getCached returns null for non-existent keys (0.1448ms)
✔ in-memory cache behavior (2.0275ms)

ℹ tests 12 | suites 2 | pass 12 | fail 0
```
```