### PR TITLE
 Protect the main branch with required quality checks

### DIFF
--- a/docs/main-branch-protection.md
+++ b/docs/main-branch-protection.md
@@ -1,0 +1,61 @@
+# Main Branch Protection
+
+The `main` branch is protected by an active branch protection rule.
+
+## Policy
+
+- All changes to `main` must arrive through a pull request.
+- At least one approving review is required.
+- Review threads must be resolved before merge.
+- Required status checks must pass and must be current with `main`.
+- Force pushes and branch deletion are blocked.
+- Administrators follow the same rules. `enforce_admins` is enabled.
+
+Emergency recovery requires temporarily editing branch protection in GitHub repository settings, recording the reason in the incident or maintenance issue, restoring branch protection immediately after recovery, and linking the audit-log entry in the follow-up.
+
+## Required Checks
+
+The deterministic checks from issue #9 are required by exact check context name:
+
+- `lint`
+- `build`
+
+If issue #9 renames the workflow jobs, update the `REQUIRED_CHECKS` value before applying branch protection so these names match the active GitHub Checks contexts.
+
+## Apply
+
+Use a token with repository `Administration: write` permission.
+
+```powershell
+$env:GITHUB_TOKEN = "<token>"
+npm run protect:main
+```
+
+For forks or renamed repositories:
+
+```powershell
+$env:GITHUB_OWNER = "lumenmap"
+$env:GITHUB_REPO = "lumenmap"
+$env:PROTECTED_BRANCH = "main"
+$env:REQUIRED_CHECKS = "lint,build"
+npm run protect:main
+```
+
+Preview the payload without contacting GitHub:
+
+```powershell
+npm run protect:main -- --dry-run
+```
+
+## Verification
+
+After applying branch protection, inspect the active GitHub response printed by the script. It should show required status checks, `enforce_admins.enabled: true`, pull request review requirements, `allow_force_pushes.enabled: false`, and `allow_deletions.enabled: false` for `main`.
+
+Then use a test pull request:
+
+- Push a branch with a deliberately failing required check and confirm GitHub blocks merge.
+- Push a branch with all required checks passing and confirm merge is available through the normal review path.
+- Confirm direct pushes to `main`, force pushes, and branch deletion are rejected by normal maintainer credentials.
+
+
+

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "protect:main": "node scripts/configure-main-protection.mjs",
     "sync:directory": "node scripts/sync-stellar-directory.mjs",
     "test:hubble": "node scripts/test-hubble-queries.mjs"
   },

--- a/scripts/configure-main-protection.mjs
+++ b/scripts/configure-main-protection.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+const DEFAULT_REQUIRED_CHECKS = ["lint", "build"];
+
+const owner = process.env.GITHUB_OWNER ?? "lumenmap";
+const repo = process.env.GITHUB_REPO ?? "lumenmap";
+const branch = process.env.PROTECTED_BRANCH ?? "main";
+const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+const apiVersion = process.env.GITHUB_API_VERSION ?? "2026-03-10";
+const requiredChecks = (process.env.REQUIRED_CHECKS ?? DEFAULT_REQUIRED_CHECKS.join(","))
+  .split(",")
+  .map((check) => check.trim())
+  .filter(Boolean);
+const dryRun = process.argv.includes("--dry-run");
+
+if (!token && !dryRun) {
+  console.error("Set GITHUB_TOKEN or GH_TOKEN with repository Administration:write permission.");
+  process.exit(1);
+}
+
+if (requiredChecks.length === 0) {
+  console.error("At least one required check is needed. Set REQUIRED_CHECKS as a comma-separated list.");
+  process.exit(1);
+}
+
+const protection = {
+  required_status_checks: {
+    strict: true,
+    contexts: requiredChecks,
+  },
+  enforce_admins: true,
+  required_pull_request_reviews: {
+    dismiss_stale_reviews: true,
+    require_code_owner_reviews: false,
+    required_approving_review_count: 1,
+    require_last_push_approval: false,
+  },
+  restrictions: null,
+  required_linear_history: false,
+  allow_force_pushes: false,
+  allow_deletions: false,
+  block_creations: false,
+  required_conversation_resolution: true,
+  lock_branch: false,
+  allow_fork_syncing: true,
+};
+
+if (dryRun) {
+  console.log(JSON.stringify(protection, null, 2));
+  process.exit(0);
+}
+
+const baseUrl = `https://api.github.com/repos/${owner}/${repo}`;
+
+const request = async (path, options = {}) => {
+  const response = await fetch(`${baseUrl}${path}`, {
+    ...options,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "X-GitHub-Api-Version": apiVersion,
+      ...options.headers,
+    },
+  });
+
+  const text = await response.text();
+  const body = text ? JSON.parse(text) : null;
+
+  if (!response.ok) {
+    const detail = body?.message ? `: ${body.message}` : "";
+    throw new Error(`${options.method ?? "GET"} ${path} failed with ${response.status}${detail}`);
+  }
+
+  return body;
+};
+
+await request(`/branches/${encodeURIComponent(branch)}/protection`, {
+  method: "PUT",
+  body: JSON.stringify(protection),
+});
+
+const activeProtection = await request(`/branches/${encodeURIComponent(branch)}/protection`);
+
+console.log(
+  JSON.stringify(
+    {
+      branch,
+      requiredChecks,
+      activeProtection,
+    },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
##closes #10 


Implemented the maintainable path for #10:
Added [scripts/configure-main-protection.mjs](/c:/Users/cisat/.antigravity-ide/lumenmap-1/scripts/configure-main-protection.mjs), which applies GitHub branch protection to main with:required PRs
1 approving review
strict required checks: lint, build
admin enforcement
force-push and deletion blocks

Added npm run protect:main in [package.json](/c:/Users/cisat/.antigravity-ide/lumenmap-1/package.json).
Added maintainer policy and verification steps in [docs/main-branch-protection.md](/c:/Users/cisat/.antigravity-ide/lumenmap-1/docs/main-branch-protection.md).
Verified locally with:
npm.cmd run protect:main -- --dry-run
I could not apply the live GitHub protection or run the test PR verification from here because this environment has no gh CLI and no GITHUB_TOKEN/GH_TOKEN with repository admin permission. The script is built against GitHub’s branch protection REST API docs: https://docs.github.com/en/rest/branches/branch-protection and repository rules/ruleset docs I checked: https://docs.github.com/en/rest/repos/rules.