### PR TITLE
fix: restore zero-error ESLint baseline

### DIFF
--- a/components/dashboard/DashboardProvider.tsx
+++ b/components/dashboard/DashboardProvider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
 import type { TreemapViewId } from "@/lib/constants";
 import type { ActivityResponse, Period, SelectedNode } from "@/lib/types";
 
@@ -34,9 +34,15 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
   const [treemapView, setTreemapView] = useState<TreemapViewId>("events");
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
 
-  useEffect(() => {
+  const handleSetPeriod = useCallback((newPeriod: Period) => {
     setSelectedNode(null);
-  }, [period, treemapView]);
+    setPeriod(newPeriod);
+  }, []);
+
+  const handleSetTreemapView = useCallback((newView: TreemapViewId) => {
+    setSelectedNode(null);
+    setTreemapView(newView);
+  }, []);
 
   const query = useQuery({
     queryKey: ["activity", period],
@@ -47,9 +53,9 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
   const value = useMemo(
     () => ({
       period,
-      setPeriod,
+      setPeriod: handleSetPeriod,
       treemapView,
-      setTreemapView,
+      setTreemapView: handleSetTreemapView,
       data: query.data,
       isLoading: query.isLoading,
       isError: query.isError,
@@ -59,7 +65,9 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
     }),
     [
       period,
+      handleSetPeriod,
       treemapView,
+      handleSetTreemapView,
       query.data,
       query.isLoading,
       query.isError,

--- a/components/dashboard/TreemapViewSelector.tsx
+++ b/components/dashboard/TreemapViewSelector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TREEMAP_VIEWS, type TreemapViewId } from "@/lib/constants";
+import { TREEMAP_VIEWS } from "@/lib/constants";
 import { Button } from "@/components/ui/button";
 import { useDashboard } from "@/components/dashboard/DashboardProvider";
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -69,8 +69,6 @@ export interface TreemapNode {
   meta?: TreemapNodeMeta;
 }
 
-import type { TreemapViewId } from "@/lib/constants";
-
 export interface ActivityTreemaps {
   events: TreemapNode;
   actors: TreemapNode;


### PR DESCRIPTION
Closes #2

This PR restores the ESLint baseline to zero errors and zero warnings by fixing two categories of issues:

### Architectural fix: `react-hooks/set-state-in-effect` (DashboardProvider)

The previous code used a `useEffect` to reset `selectedNode` to `null` whenever `period` or `treemapView` changed:

```javascript
useEffect(() => {
  setSelectedNode(null);
}, [period, treemapView]);

This violated the React rule against calling `setState` synchronously inside an effect. The fix replaces the effect with **wrapper handlers** (`handleSetPeriod`, `handleSetTreemapView`) that clear `selectedNode` at the call site — the same event handler that triggers the period/view change. The context exposes these wrappers in place of the raw state setters, preserving the exact same behavior without the anti-pattern.

### Unused imports removed

* `TreemapViewId` import in `TreemapViewSelector.tsx` (consumed `TREEMAP_VIEWS` without needing the type)
* `TreemapViewId` import in `lib/types.ts` (the type was never referenced in the file)

### Verification

* `npm run lint` exits cleanly with no errors and no warnings.