### PR TITLE
fix(hubble): load Next.js environment variables in smoke-test script #6

### DIFF
--- a/scripts/test-hubble-queries.mjs
+++ b/scripts/test-hubble-queries.mjs
@@ -1,6 +1,21 @@
 #!/usr/bin/env node
 
+import pkg from "@next/env";
 import { BigQuery } from "@google-cloud/bigquery";
+
+const { loadEnvConfig } = pkg;
+loadEnvConfig(process.cwd());
+
+const keyBase64 = process.env.GCP_SERVICE_ACCOUNT_KEY;
+const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+
+if (!keyBase64 && !credPath) {
+  console.error(
+    "No GCP credentials found. Set GOOGLE_APPLICATION_CREDENTIALS or GCP_SERVICE_ACCOUNT_KEY in your .env.local file.",
+  );
+  console.error("See .env.example for the required variables.");
+  process.exit(1);
+}
 
 const TOP_ACCOUNTS_PER_TYPE = 70;
 const TOP_CONTRACT_LIMIT = 200;
@@ -100,9 +115,20 @@ const end = new Date().toISOString();
 const start = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
 const baseParams = { start, end };
 
-const client = new BigQuery({
-  projectId: process.env.GCP_PROJECT_ID ?? "stellar-501912",
-});
+let client;
+if (keyBase64) {
+  const credentials = JSON.parse(
+    Buffer.from(keyBase64, "base64").toString("utf-8"),
+  );
+  client = new BigQuery({
+    projectId: credentials.project_id,
+    credentials,
+  });
+} else {
+  client = new BigQuery({
+    projectId: process.env.GCP_PROJECT_ID ?? "stellar-501912",
+  });
+}
 
 const queries = [
   { name: "categoryQuery", sql: categoryQuery, params: baseParams },


### PR DESCRIPTION
## Overview

This PR fixes `npm run test:hubble` so it loads Next.js environment variables via `@next/env`'s `loadEnvConfig`. Previously the script ran as plain Node.js and never picked up `.env.local` — so contributors who followed the documented setup would get a default-credentials failure.

## Related Issue

Closes #6

## Changes

### 🔧 Hubble Smoke-Test Script

- **`scripts/test-hubble-queries.mjs`** — Added `loadEnvConfig(process.cwd())` at startup to load `.env*` files using the same mechanism as Next.js.
- **Credential validation** — Before running any queries, the script checks for `GOOGLE_APPLICATION_CREDENTIALS` or `GCP_SERVICE_ACCOUNT_KEY`. If neither is set, it prints one concise actionable error and exits with code 1.
- **Dual auth support** — `GCP_SERVICE_ACCOUNT_KEY` (base64) is decoded and passed as explicit `credentials` to the BigQuery client, matching the runtime path in `lib/hubble/client.ts`. Falls back to `GOOGLE_APPLICATION_CREDENTIALS` for ADC.
- **Shell env precedence** — `loadEnvConfig` preserves existing `process.env` values, so shell-set variables override `.env*` files.
- **Secrets never logged** — Credential values are read into local variables and never printed to output.

## Verification Results

```
# Without credentials — fails early with setup message
$ node scripts/test-hubble-queries.mjs
No GCP credentials found. Set GOOGLE_APPLICATION_CREDENTIALS or GCP_SERVICE_ACCOUNT_KEY in your .env.local file.
See .env.example for the required variables.
$ echo $?
1

# With .env.local — reaches query execution
$ cp .env.example .env.local
$ node scripts/test-hubble-queries.mjs
Testing categoryQuery... FAILED
(The fake gcp-sa.json doesn't exist, but the credential check passed)
```

## Acceptance Criteria

| Criteria | Status |
|---|---|
| Script reads `GOOGLE_APPLICATION_CREDENTIALS` or `GCP_SERVICE_ACCOUNT_KEY` from `.env.local` | ✅ Uses `@next/env` `loadEnvConfig` — same mechanism as Next.js |
| Existing shell env vars take precedence | ✅ Verified: shell `$env:GOOGLE_APPLICATION_CREDENTIALS` overrides `.env.local` |
| Missing credentials produce one concise actionable error | ✅ Single message with both variable names and reference to `.env.example` |
| Credential values are never logged | ✅ Read into local variables, never printed |