### PR TITLE
fix: eliminate horizontal overflow at 320-390px viewports

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -27,6 +27,8 @@
 html,
 body {
   min-height: 100%;
+  max-width: 100vw;
+  overflow-x: hidden;
 }
 
 body {

--- a/components/dashboard/D3Treemap.tsx
+++ b/components/dashboard/D3Treemap.tsx
@@ -74,7 +74,7 @@ export function D3Treemap({ root, onSelect }: D3TreemapProps) {
 
       const { width, height } = entry.contentRect;
       setSize({
-        width: Math.max(Math.floor(width), 320),
+        width: Math.max(Math.floor(width), 0),
         height: Math.max(Math.floor(height), 280),
       });
     });
@@ -182,7 +182,7 @@ export function D3Treemap({ root, onSelect }: D3TreemapProps) {
         <svg
           width={size.width}
           height={size.height}
-          className="block overflow-hidden rounded-lg"
+          className="block max-w-full overflow-hidden rounded-lg"
           role="img"
           aria-label="Network activity treemap"
         >

--- a/components/dashboard/DashboardPage.tsx
+++ b/components/dashboard/DashboardPage.tsx
@@ -29,7 +29,7 @@ function DataSourceNotice() {
 
 function DashboardContent() {
   return (
-    <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
+    <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 overflow-x-hidden px-4 py-6 sm:px-6 lg:px-8">
       <header className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div className="space-y-3">
           <div className="flex flex-wrap items-center gap-3">
@@ -42,10 +42,10 @@ function DashboardContent() {
               priority
             />
             <div>
-              <h1 className="text-2xl font-semibold tracking-tight text-white sm:text-3xl">
+              <h1 className="text-xl font-semibold tracking-tight text-white sm:text-2xl lg:text-3xl">
                 LumenMap
               </h1>
-              <p className="text-sm text-zinc-400">
+              <p className="text-xs text-zinc-400 sm:text-sm">
                 Stellar network activity across mainnet.
               </p>
             </div>

--- a/components/dashboard/KpiCards.tsx
+++ b/components/dashboard/KpiCards.tsx
@@ -66,7 +66,7 @@ export function KpiCards() {
               <Icon className="h-4 w-4 text-stellar-light" />
             </CardHeader>
             <CardContent>
-              <p className="text-2xl font-semibold text-white">
+              <p className="text-lg font-semibold text-white sm:text-xl lg:text-2xl">
                 {item.format(value as never)}
               </p>
             </CardContent>

--- a/components/dashboard/NetworkTreemap.tsx
+++ b/components/dashboard/NetworkTreemap.tsx
@@ -83,10 +83,10 @@ export function NetworkTreemap() {
           ))}
         </div>
       </CardHeader>
-      <CardContent>
+      <CardContent className="min-w-0">
         <div
           key={`${period}-${treemapView}`}
-          className="h-[420px] sm:h-[520px] lg:h-[600px] overflow-hidden rounded-xl border border-white/5 bg-black/20 p-2 sm:p-3"
+          className="h-[420px] sm:h-[520px] lg:h-[600px] max-w-full overflow-hidden rounded-xl border border-white/5 bg-black/20 p-2 sm:p-3"
         >
           <D3Treemap root={activeTreemap} onSelect={setSelectedNode} />
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "stellar-treemap",
+  "name": "lumenmap",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "stellar-treemap",
+      "name": "lumenmap",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@google-cloud/bigquery": "^8.3.1",
         "@tanstack/react-query": "^5.101.2",
@@ -76,7 +77,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -286,12 +286,31 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
       "dev": true,
-      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -1700,7 +1719,6 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1760,7 +1778,6 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -2364,7 +2381,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2771,7 +2787,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -3445,7 +3460,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3631,7 +3645,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6065,7 +6078,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6075,7 +6087,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6870,7 +6881,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7033,7 +7043,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7333,7 +7342,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "start": "next start",
     "lint": "eslint",
     "sync:directory": "node scripts/sync-stellar-directory.mjs",
-    "test:hubble": "node scripts/test-hubble-queries.mjs"
+    "test:hubble": "node scripts/test-hubble-queries.mjs",
+    "test:responsive-overflow": "node scripts/test-responsive-overflow.mjs"
   },
   "dependencies": {
     "@google-cloud/bigquery": "^8.3.1",

--- a/scripts/test-responsive-overflow.mjs
+++ b/scripts/test-responsive-overflow.mjs
@@ -1,0 +1,128 @@
+/**
+ * Regression test: verify that horizontal overflow protections are in place
+ * for 320–390 pixel viewports.
+ *
+ * Checks:
+ *  - globals.css has overflow-x: hidden and max-width: 100vw on html/body
+ *  - D3Treemap.tsx does NOT contain a 320px minimum width in ResizeObserver
+ *  - key containers have max-w-full or overflow-x-hidden classes
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    passed++;
+    console.log(`  ✅ ${message}`);
+  } else {
+    failed++;
+    console.error(`  ❌ ${message}`);
+  }
+}
+
+function fileContains(filePath, needle) {
+  try {
+    const content = readFileSync(resolve(root, filePath), "utf8");
+    return content.includes(needle);
+  } catch {
+    return false;
+  }
+}
+
+function fileDoesNotContain(filePath, needle) {
+  try {
+    const content = readFileSync(resolve(root, filePath), "utf8");
+    return !content.includes(needle);
+  } catch {
+    return false;
+  }
+}
+
+console.log("\n🔍 Responsive Overflow Regression Tests\n");
+
+// 1. globals.css: html/body block has overflow-x: hidden
+assert(
+  fileContains("app/globals.css", "overflow-x: hidden") &&
+    fileContains("app/globals.css", "max-width: 100vw"),
+  "globals.css sets overflow-x: hidden and max-width: 100vw on html/body",
+);
+
+// 2. D3Treemap.tsx: should NOT contain Math.max(..., 320) for width
+assert(
+  fileDoesNotContain(
+    "components/dashboard/D3Treemap.tsx",
+    "Math.max(Math.floor(width), 320)",
+  ),
+  "D3Treemap.tsx no longer has 320px minimum width constraint",
+);
+
+// 3. D3Treemap.tsx: width is now Math.max(Math.floor(width), 0)
+assert(
+  fileContains("components/dashboard/D3Treemap.tsx", "Math.max(Math.floor(width), 0)"),
+  "D3Treemap.tsx uses safe Math.max(Math.floor(width), 0) for width",
+);
+
+// 4. D3Treemap.tsx: SVG has max-w-full
+assert(
+  fileContains("components/dashboard/D3Treemap.tsx", "max-w-full overflow-hidden rounded-lg"),
+  "D3Treemap.tsx SVG has max-w-full class",
+);
+
+// 5. DashboardPage.tsx: main container has overflow-x-hidden
+assert(
+  fileContains("components/dashboard/DashboardPage.tsx", "overflow-x-hidden"),
+  "DashboardPage.tsx main container has overflow-x-hidden",
+);
+
+// 6. KpiCards.tsx: value text is responsive (not fixed text-2xl only)
+assert(
+  fileContains("components/dashboard/KpiCards.tsx", "sm:text-xl") &&
+    fileContains("components/dashboard/KpiCards.tsx", "lg:text-2xl"),
+  "KpiCards.tsx values use responsive text sizing (text-lg sm:text-xl lg:text-2xl)",
+);
+
+// 7. NetworkTreemap.tsx: treemap container has max-w-full
+assert(
+  fileContains("components/dashboard/NetworkTreemap.tsx", "max-w-full"),
+  "NetworkTreemap.tsx treemap container has max-w-full",
+);
+
+// 8. NetworkTreemap.tsx: CardContent has min-w-0
+assert(
+  fileContains("components/dashboard/NetworkTreemap.tsx", "min-w-0"),
+  "NetworkTreemap.tsx CardContent has min-w-0 to allow shrinking",
+);
+
+// 9. PeriodSelector.tsx: uses flex-wrap for buttons
+assert(
+  fileContains("components/dashboard/PeriodSelector.tsx", "flex-wrap"),
+  "PeriodSelector.tsx uses flex-wrap for period buttons",
+);
+
+// 10. TreemapViewSelector.tsx: uses flex-wrap for view selector
+assert(
+  fileContains("components/dashboard/TreemapViewSelector.tsx", "flex-wrap"),
+  "TreemapViewSelector.tsx uses flex-wrap for view selector buttons",
+);
+
+// 11. NetworkTreemap.tsx: legend uses flex-wrap
+assert(
+  fileContains("components/dashboard/NetworkTreemap.tsx", "flex flex-wrap gap-2"),
+  "NetworkTreemap.tsx legend uses flex-wrap",
+);
+
+console.log(`\n📊 Results: ${passed} passed, ${failed} failed out of ${passed + failed} checks\n`);
+
+if (failed > 0) {
+  process.exit(1);
+}
+
+console.log("🎉 All responsive overflow protections are in place!\n");


### PR DESCRIPTION
closes #71 

## Problem

The deployed dashboard clips the header, KPI cards, legend, controls, and treemap at narrow mobile widths (320-390px viewports).

## Changes

- **globals.css**: Add `max-width: 100vw` and `overflow-x: hidden` to html/body
- **D3Treemap.tsx**: Remove 320px min-width from ResizeObserver (replaced with `Math.max(width, 0)`), add `max-w-full` to SVG
- **KpiCards.tsx**: Responsive value font sizing (`text-lg sm:text-xl lg:text-2xl`)
- **DashboardPage.tsx**: Responsive header sizing, `overflow-x-hidden` on main container
- **NetworkTreemap.tsx**: Add `min-w-0` to CardContent, `max-w-full` to treemap container
- **Regression**: New `npm run test:responsive-overflow` script (11 assertions)

## Verification

- ✅ `npm run test:responsive-overflow` — 11/11 passed
- ✅ `npm run lint` — no new issues (3 pre-existing)
- ✅ `npm run build` — compiles successfully

