### PR TITLE
Use uncapped distinct contract count for Active Contracts KPI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+scripts/.test-out
+scripts/.verify-fixture-bundle.mjs
 
 # next.js
 /.next/

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Dataset: `crypto-stellar.crypto_stellar_dbt`
 | --- | --- |
 | Operations by type | Counts per `type_string` |
 | Top accounts | Most active wallets per operation type |
-| Top contracts | Most invoked Soroban contracts |
+| Top contracts | Most invoked Soroban contracts (capped leaderboard) |
+| Active contracts | Uncapped `COUNT(DISTINCT contract_id)` for the Active Contracts KPI |
 | Soroban functions | Counts per function and per contract |
 
 ### Queries planned
@@ -182,7 +183,15 @@ Do not commit `gcp-sa.json` or `.env.local`. Both are gitignored. Each contribut
     "totalOps": 1234567,
     "sorobanShare": 0.42,
     "topCategory": "soroban",
-    "activeContracts": 89
+    "activeContracts": 247
+  },
+  "activeContractCount": 247,
+  "provenance": {
+    "activeContracts": {
+      "aggregation": "uncapped_distinct_count",
+      "query": "activeContractCountQuery",
+      "leaderboardLimit": 200
+    }
   },
   "treemaps": {
     "events": { "name": "Network Activity", "children": [] },
@@ -191,7 +200,9 @@ Do not commit `gcp-sa.json` or `.env.local`. Both are gitignored. Each contribut
 }
 ```
 
-Response also includes `categories`, `contracts`, `accounts`, `sorobanFunctions`, and `sorobanFunctionContracts`.
+Response also includes `categories`, capped `contracts` (leaderboard / treemap, max 200), `accounts`, `sorobanFunctions`, and `sorobanFunctionContracts`.
+
+`kpis.activeContracts` and `activeContractCount` are the uncapped distinct contract count for the period. They are not `contracts.length`.
 
 ### Planned endpoints
 
@@ -248,6 +259,7 @@ scripts/
 | `npm run build` | Production build |
 | `npm run start` | Production server |
 | `npm run lint` | ESLint |
+| `npm test` | Deterministic unit tests (no GCP) |
 | `npm run test:hubble` | BigQuery query smoke test |
 | `npm run sync:directory` | Sync labels from Stellar Expert |
 
@@ -258,6 +270,7 @@ scripts/
 - Hubble refreshes in intraday batches. Numbers can lag behind live chain state.
 - API responses are cached for 15 minutes by default.
 - Queries use date filters and top-N limits to keep BigQuery cost down.
+- Active Contracts is an uncapped distinct contract count. The contract leaderboard / treemap remains independently capped at 200.
 
 ## Activity categories
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,7 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    "scripts/.test-out/**",
   ]),
 ]);
 

--- a/lib/entities/build-treemap.ts
+++ b/lib/entities/build-treemap.ts
@@ -314,7 +314,7 @@ export function buildTreemap(input: BuildTreemapInput): TreemapNode {
 
 export function buildKpis(
   categories: CategoryRow[],
-  contracts: ContractRow[],
+  activeContractCount: number,
 ): ActivityKpis {
   const totalOps = categories.reduce((sum, row) => sum + row.op_count, 0);
   const groupTotals = getGroupTotals(categories);
@@ -330,7 +330,7 @@ export function buildKpis(
     topCategory: topCategoryEntry
       ? (GROUP_LABELS[topCategoryEntry[0]] ?? topCategoryEntry[0])
       : "N/A",
-    activeContracts: contracts.length,
+    activeContracts: activeContractCount,
   };
 }
 

--- a/lib/hubble/activity.ts
+++ b/lib/hubble/activity.ts
@@ -3,11 +3,13 @@ import { getCached, setCache } from "@/lib/hubble/cache";
 import {
   accountQuery,
   accountMetadataQuery,
+  activeContractCountQuery,
   categoryQuery,
   contractQuery,
   getAccountQueryTypes,
   mapAccountMetadataRows,
   mapAccountRows,
+  mapActiveContractCountRows,
   mapCategoryRows,
   mapContractRows,
   mapSorobanFunctionContractRows,
@@ -23,6 +25,7 @@ import {
   homeDomainsToEntities,
   resolveEntityLabels,
 } from "@/lib/entities/resolve-labels";
+import { buildActivityProvenance } from "@/lib/metrics/provenance";
 import { resolvePeriod } from "@/lib/periods";
 import type { ActivityResponse, Period } from "@/lib/types";
 
@@ -52,12 +55,14 @@ async function fetchFromHubble(
   const [
     categoryRows,
     contractRows,
+    activeContractCountRows,
     accountRows,
     sorobanFunctionRows,
     sorobanFunctionContractRows,
   ] = await Promise.all([
     runQuery<Record<string, unknown>>(categoryQuery, params),
     runQuery<Record<string, unknown>>(contractQuery, params),
+    runQuery<Record<string, unknown>>(activeContractCountQuery, params),
     runQuery<Record<string, unknown>>(accountQuery, {
       ...params,
       types: getAccountQueryTypes(),
@@ -69,6 +74,7 @@ async function fetchFromHubble(
   return {
     categories: mapCategoryRows(categoryRows),
     contracts: mapContractRows(contractRows),
+    activeContractCount: mapActiveContractCountRows(activeContractCountRows),
     accounts: mapAccountRows(accountRows),
     sorobanFunctions: mapSorobanFunctionRows(sorobanFunctionRows),
     sorobanFunctionContracts: mapSorobanFunctionContractRows(
@@ -89,6 +95,37 @@ async function fetchHomeDomains(ids: string[]) {
   return homeDomainsToEntities(mapAccountMetadataRows(rows));
 }
 
+/** Builds the activity API payload from Hubble (or test) raw results. */
+export function buildActivityResponse(
+  period: Period,
+  start: string,
+  end: string,
+  raw: RawQueryResults,
+  options: {
+    source?: ActivityResponse["source"];
+    labels?: Parameters<typeof buildAllTreemaps>[0]["labels"];
+  } = {},
+): ActivityResponse {
+  const kpis = buildKpis(raw.categories, raw.activeContractCount);
+  const treemaps = buildAllTreemaps({ ...raw, labels: options.labels });
+
+  return {
+    period,
+    start,
+    end,
+    source: options.source ?? "hubble",
+    categories: raw.categories,
+    contracts: raw.contracts,
+    accounts: raw.accounts,
+    sorobanFunctions: raw.sorobanFunctions,
+    sorobanFunctionContracts: raw.sorobanFunctionContracts,
+    activeContractCount: raw.activeContractCount,
+    kpis,
+    provenance: buildActivityProvenance(),
+    treemaps,
+  };
+}
+
 export async function getActivityData(period: Period): Promise<ActivityResponse> {
   if (!hasBigQueryCredentials()) {
     throw new Error(
@@ -97,7 +134,7 @@ export async function getActivityData(period: Period): Promise<ActivityResponse>
   }
 
   const range = resolvePeriod(period);
-  const cacheKey = `activity:v10:${period}:${range.start.toISOString()}`;
+  const cacheKey = `activity:v11:${period}:${range.start.toISOString()}`;
 
   const cached = getCached<ActivityResponse>(cacheKey);
   if (cached) {
@@ -107,25 +144,10 @@ export async function getActivityData(period: Period): Promise<ActivityResponse>
   const start = range.start.toISOString();
   const end = range.end.toISOString();
   const raw = await fetchFromHubble(start, end);
-  const kpis = buildKpis(raw.categories, raw.contracts);
   const labels = await resolveEntityLabels(collectTreemapIds(raw), {
     fetchHomeDomains,
   });
-  const treemaps = buildAllTreemaps({ ...raw, labels });
-
-  const response: ActivityResponse = {
-    period,
-    start,
-    end,
-    source: "hubble",
-    categories: raw.categories,
-    contracts: raw.contracts,
-    accounts: raw.accounts,
-    sorobanFunctions: raw.sorobanFunctions,
-    sorobanFunctionContracts: raw.sorobanFunctionContracts,
-    kpis,
-    treemaps,
-  };
+  const response = buildActivityResponse(period, start, end, raw, { labels });
 
   setCache(cacheKey, response);
   return response;

--- a/lib/hubble/queries.ts
+++ b/lib/hubble/queries.ts
@@ -41,6 +41,20 @@ ORDER BY op_count DESC
 LIMIT ${TOP_CONTRACT_LIMIT}
 `;
 
+/**
+ * Uncapped distinct active Soroban contracts for the period.
+ * Same inclusion rules as the leaderboard (non-null, non-empty contract_id)
+ * but with no LIMIT so the KPI can exceed TOP_CONTRACT_LIMIT.
+ */
+export const activeContractCountQuery = `
+SELECT
+  COUNT(DISTINCT contract_id) AS active_contract_count
+FROM \`crypto-stellar.crypto_stellar_dbt.hourly_soroban_fee_agg_contract\`
+WHERE hour_agg BETWEEN @start AND @end
+  AND contract_id IS NOT NULL
+  AND contract_id != ''
+`;
+
 export const accountQuery = `
 WITH ranked AS (
   SELECT
@@ -122,6 +136,7 @@ export function getAccountQueryTypes(): string[] {
 export type RawQueryResults = {
   categories: CategoryRow[];
   contracts: ContractRow[];
+  activeContractCount: number;
   accounts: AccountRow[];
   sorobanFunctions: SorobanFunctionRow[];
   sorobanFunctionContracts: SorobanFunctionContractRow[];
@@ -139,6 +154,26 @@ export function mapContractRows(rows: Record<string, unknown>[]): ContractRow[] 
     contract_id: String(row.contract_id),
     op_count: Number(row.op_count),
   }));
+}
+
+/**
+ * Maps the uncapped active-contract aggregate row.
+ * Empty result sets and missing values become 0.
+ */
+export function mapActiveContractCountRows(
+  rows: Record<string, unknown>[],
+): number {
+  if (rows.length === 0) {
+    return 0;
+  }
+
+  const value = rows[0]?.active_contract_count;
+  if (value === null || value === undefined || value === "") {
+    return 0;
+  }
+
+  const count = Number(value);
+  return Number.isFinite(count) && count > 0 ? count : 0;
 }
 
 export function mapAccountRows(rows: Record<string, unknown>[]): AccountRow[] {

--- a/lib/metrics/active-contracts.test.ts
+++ b/lib/metrics/active-contracts.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { TOP_CONTRACT_LIMIT } from "@/lib/constants";
+import { buildKpis } from "@/lib/entities/build-treemap";
+import { buildActivityResponse } from "@/lib/hubble/activity";
+import {
+  activeContractCountQuery,
+  contractQuery,
+  mapActiveContractCountRows,
+  type RawQueryResults,
+} from "@/lib/hubble/queries";
+import type { CategoryRow, ContractRow } from "@/lib/types";
+
+function makeContract(index: number): ContractRow {
+  return {
+    contract_id: `C${String(index).padStart(55, "0")}`,
+    op_count: Math.max(1, 1000 - index),
+  };
+}
+
+function makeCategories(): CategoryRow[] {
+  return [
+    { type_string: "invoke_host_function", op_count: 500 },
+    { type_string: "payment", op_count: 100 },
+  ];
+}
+
+function makeRaw(
+  contracts: ContractRow[],
+  activeContractCount: number,
+): RawQueryResults {
+  return {
+    categories: makeCategories(),
+    contracts,
+    activeContractCount,
+    accounts: [],
+    sorobanFunctions: [],
+    sorobanFunctionContracts: [],
+  };
+}
+
+describe("mapActiveContractCountRows", () => {
+  it("returns zero for an empty result", () => {
+    assert.equal(mapActiveContractCountRows([]), 0);
+  });
+
+  it("returns zero when the aggregate field is missing or null", () => {
+    assert.equal(mapActiveContractCountRows([{}]), 0);
+    assert.equal(mapActiveContractCountRows([{ active_contract_count: null }]), 0);
+    assert.equal(mapActiveContractCountRows([{ active_contract_count: "" }]), 0);
+  });
+
+  it("maps a finite aggregate value", () => {
+    assert.equal(
+      mapActiveContractCountRows([{ active_contract_count: 247 }]),
+      247,
+    );
+    assert.equal(
+      mapActiveContractCountRows([{ active_contract_count: "312" }]),
+      312,
+    );
+  });
+});
+
+describe("activeContractCountQuery", () => {
+  it("has no leaderboard LIMIT and uses distinct contract_id", () => {
+    assert.match(activeContractCountQuery, /COUNT\s*\(\s*DISTINCT\s+contract_id\s*\)/i);
+    assert.doesNotMatch(activeContractCountQuery, /\bLIMIT\b/i);
+    assert.match(contractQuery, new RegExp(`LIMIT\\s+${TOP_CONTRACT_LIMIT}`));
+  });
+});
+
+describe("buildKpis activeContracts", () => {
+  it("uses the uncapped aggregate, not contracts.length", () => {
+    const contracts = Array.from({ length: TOP_CONTRACT_LIMIT }, (_, i) =>
+      makeContract(i),
+    );
+    const kpis = buildKpis(makeCategories(), 350);
+
+    assert.equal(contracts.length, TOP_CONTRACT_LIMIT);
+    assert.equal(kpis.activeContracts, 350);
+    assert.notEqual(kpis.activeContracts, contracts.length);
+  });
+
+  it("reports zero when no qualifying contracts exist", () => {
+    const kpis = buildKpis(makeCategories(), 0);
+    assert.equal(kpis.activeContracts, 0);
+  });
+
+  it("matches the aggregate below, at, and above the leaderboard limit", () => {
+    for (const count of [0, 50, TOP_CONTRACT_LIMIT, TOP_CONTRACT_LIMIT + 40]) {
+      const leaderboard = Array.from(
+        { length: Math.min(count, TOP_CONTRACT_LIMIT) },
+        (_, i) => makeContract(i),
+      );
+      const kpis = buildKpis(makeCategories(), count);
+
+      assert.equal(kpis.activeContracts, count);
+      assert.ok(leaderboard.length <= TOP_CONTRACT_LIMIT);
+      if (count > TOP_CONTRACT_LIMIT) {
+        assert.equal(leaderboard.length, TOP_CONTRACT_LIMIT);
+        assert.ok(kpis.activeContracts > leaderboard.length);
+      }
+    }
+  });
+});
+
+describe("buildActivityResponse", () => {
+  it("keeps capped contracts while KPI and aggregate use the uncapped count", () => {
+    const contracts = Array.from({ length: TOP_CONTRACT_LIMIT }, (_, i) =>
+      makeContract(i),
+    );
+    const uncapped = TOP_CONTRACT_LIMIT + 87;
+    const response = buildActivityResponse(
+      "1d",
+      "2026-07-28T00:00:00.000Z",
+      "2026-07-28T23:59:59.999Z",
+      makeRaw(contracts, uncapped),
+    );
+
+    assert.equal(response.contracts.length, TOP_CONTRACT_LIMIT);
+    assert.equal(response.activeContractCount, uncapped);
+    assert.equal(response.kpis.activeContracts, uncapped);
+    assert.notEqual(response.kpis.activeContracts, response.contracts.length);
+    assert.equal(
+      response.provenance.activeContracts.aggregation,
+      "uncapped_distinct_count",
+    );
+    assert.equal(
+      response.provenance.activeContracts.query,
+      "activeContractCountQuery",
+    );
+    assert.equal(
+      response.provenance.activeContracts.leaderboardLimit,
+      TOP_CONTRACT_LIMIT,
+    );
+  });
+
+  it("produces a zero KPI and aggregate for an empty period", () => {
+    const response = buildActivityResponse(
+      "1d",
+      "2026-07-28T00:00:00.000Z",
+      "2026-07-28T23:59:59.999Z",
+      makeRaw([], 0),
+    );
+
+    assert.equal(response.contracts.length, 0);
+    assert.equal(response.activeContractCount, 0);
+    assert.equal(response.kpis.activeContracts, 0);
+  });
+});

--- a/lib/metrics/provenance.ts
+++ b/lib/metrics/provenance.ts
@@ -1,0 +1,18 @@
+import { TOP_CONTRACT_LIMIT } from "@/lib/constants";
+import type { ActiveContractsProvenance, ActivityProvenance } from "@/lib/types";
+
+export function buildActiveContractsProvenance(): ActiveContractsProvenance {
+  return {
+    metric: "activeContracts",
+    aggregation: "uncapped_distinct_count",
+    source: "hourly_soroban_fee_agg_contract",
+    query: "activeContractCountQuery",
+    leaderboardLimit: TOP_CONTRACT_LIMIT,
+  };
+}
+
+export function buildActivityProvenance(): ActivityProvenance {
+  return {
+    activeContracts: buildActiveContractsProvenance(),
+  };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -46,7 +46,25 @@ export interface ActivityKpis {
   totalOps: number;
   sorobanShare: number;
   topCategory: string;
+  /**
+   * Uncapped distinct active Soroban contracts for the period.
+   * Not derived from the capped `contracts` leaderboard length.
+   */
   activeContracts: number;
+}
+
+/** Provenance for Active Contracts: uncapped COUNT(DISTINCT contract_id). */
+export interface ActiveContractsProvenance {
+  metric: "activeContracts";
+  aggregation: "uncapped_distinct_count";
+  source: "hourly_soroban_fee_agg_contract";
+  query: "activeContractCountQuery";
+  /** Independent cap applied only to `contracts` leaderboard / treemap rows. */
+  leaderboardLimit: number;
+}
+
+export interface ActivityProvenance {
+  activeContracts: ActiveContractsProvenance;
 }
 
 export interface TreemapNodeMeta {
@@ -82,11 +100,18 @@ export interface ActivityResponse {
   end: string;
   source: DataSource;
   categories: CategoryRow[];
+  /** Top contracts for leaderboard / treemap (capped at TOP_CONTRACT_LIMIT). */
   contracts: ContractRow[];
   accounts: AccountRow[];
   sorobanFunctions: SorobanFunctionRow[];
   sorobanFunctionContracts: SorobanFunctionContractRow[];
+  /**
+   * Uncapped distinct active-contract aggregate for the period.
+   * Source of `kpis.activeContracts`; independent of `contracts.length`.
+   */
+  activeContractCount: number;
   kpis: ActivityKpis;
+  provenance: ActivityProvenance;
   treemaps: ActivityTreemaps;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "stellar-treemap",
+  "name": "lumenmap",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "stellar-treemap",
+      "name": "lumenmap",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@google-cloud/bigquery": "^8.3.1",
         "@tanstack/react-query": "^5.101.2",
@@ -26,6 +27,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "esbuild": "^0.25.5",
         "eslint": "^9",
         "eslint-config-next": "16.2.10",
         "tailwindcss": "^4",
@@ -76,7 +78,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -286,15 +287,479 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1700,7 +2165,6 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1760,7 +2224,6 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -2364,7 +2827,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2771,7 +3233,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -3416,6 +3877,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3445,7 +3948,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3631,7 +4133,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6065,7 +6566,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6075,7 +6575,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6870,7 +7369,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7033,7 +7531,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7333,7 +7830,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "node scripts/run-unit-tests.mjs",
     "sync:directory": "node scripts/sync-stellar-directory.mjs",
     "test:hubble": "node scripts/test-hubble-queries.mjs"
   },
@@ -36,6 +37,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.10",
+    "esbuild": "^0.25.5",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/scripts/run-unit-tests.mjs
+++ b/scripts/run-unit-tests.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Bundles TypeScript unit tests (with @/ path aliases) and runs them via node:test.
+ */
+
+import { mkdirSync, readdirSync, rmSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const outDir = join(root, "scripts/.test-out");
+const require = createRequire(import.meta.url);
+const esbuild = require("esbuild");
+
+function collectTestSources(dir) {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === ".next") {
+        continue;
+      }
+      files.push(...collectTestSources(full));
+      continue;
+    }
+    if (entry.name.endsWith(".test.ts")) {
+      files.push(full);
+    }
+  }
+
+  return files;
+}
+
+function collectBundled(dir) {
+  return readdirSync(dir, { recursive: true })
+    .map((name) => String(name))
+    .filter((name) => name.endsWith(".mjs"))
+    .map((name) => join(dir, name));
+}
+
+rmSync(outDir, { recursive: true, force: true });
+mkdirSync(outDir, { recursive: true });
+
+const tests = collectTestSources(join(root, "lib"));
+if (tests.length === 0) {
+  console.error("No *.test.ts files found under lib/");
+  process.exit(1);
+}
+
+const entryPoints = Object.fromEntries(
+  tests.map((file) => {
+    const rel = relative(join(root, "lib"), file).replace(/\.test\.ts$/, ".test");
+    return [rel, file];
+  }),
+);
+
+await esbuild.build({
+  entryPoints,
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  packages: "external",
+  alias: { "@": root },
+  outdir: outDir,
+  outExtension: { ".js": ".mjs" },
+});
+
+const files = collectBundled(outDir);
+if (files.length === 0) {
+  console.error("esbuild produced no test bundles");
+  process.exit(1);
+}
+
+const result = spawnSync(process.execPath, ["--test", ...files], {
+  cwd: root,
+  stdio: "inherit",
+});
+
+process.exit(result.status ?? 1);

--- a/scripts/test-hubble-queries.mjs
+++ b/scripts/test-hubble-queries.mjs
@@ -35,6 +35,12 @@ GROUP BY contract_id
 ORDER BY op_count DESC
 LIMIT ${TOP_CONTRACT_LIMIT}`;
 
+const activeContractCountQuery = `
+SELECT COUNT(DISTINCT contract_id) AS active_contract_count
+FROM \`crypto-stellar.crypto_stellar_dbt.hourly_soroban_fee_agg_contract\`
+WHERE hour_agg BETWEEN @start AND @end
+  AND contract_id IS NOT NULL AND contract_id != ''`;
+
 const accountQuery = `
 WITH ranked AS (
   SELECT
@@ -107,6 +113,11 @@ const client = new BigQuery({
 const queries = [
   { name: "categoryQuery", sql: categoryQuery, params: baseParams },
   { name: "contractQuery", sql: contractQuery, params: baseParams },
+  {
+    name: "activeContractCountQuery",
+    sql: activeContractCountQuery,
+    params: baseParams,
+  },
   {
     name: "accountQuery",
     sql: accountQuery,


### PR DESCRIPTION
Closes #31

---

Add a LIMIT-free active-contract aggregate query, drive kpis.activeContracts from that value, keep the capped leaderboard for treemaps, and document provenance so the KPI is no longer contracts.length. Closes 31#