### PR TITLE
Add inline metric definitions linked to methodology.

### DIFF
--- a/app/methodology/page.tsx
+++ b/app/methodology/page.tsx
@@ -1,0 +1,111 @@
+import Link from "next/link";
+import {
+  METHODOLOGY_SECTIONS,
+  METHODOLOGY_VERSION,
+} from "@/lib/metrics/methodology";
+
+export const metadata = {
+  title: "Metric methodology · LumenMap",
+  description:
+    "Canonical definitions for LumenMap operations, transactions, volume, TVL, and related activity metrics.",
+};
+
+export default function MethodologyPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 py-10 sm:px-6">
+      <header className="space-y-3">
+        <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">
+          Methodology v{METHODOLOGY_VERSION}
+        </p>
+        <h1 className="text-3xl font-semibold tracking-tight text-white">
+          Metric methodology
+        </h1>
+        <p className="text-sm leading-relaxed text-zinc-400">
+          Canonical counting rules for LumenMap metrics. These definitions are
+          descriptive of how the product measures activity; they are not
+          marketing claims about network health or protocol performance.
+        </p>
+        <Link
+          href="/"
+          className="inline-flex text-sm text-stellar-light hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stellar rounded-sm"
+        >
+          ← Back to dashboard
+        </Link>
+      </header>
+
+      <nav aria-label="Methodology sections" className="rounded-xl border border-white/10 bg-white/5 p-4">
+        <ul className="flex flex-col gap-2 text-sm">
+          {METHODOLOGY_SECTIONS.map((section) => (
+            <li key={section.id}>
+              <a
+                href={`#${section.id}`}
+                className="text-zinc-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stellar rounded-sm"
+              >
+                {section.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <div className="space-y-8">
+        {METHODOLOGY_SECTIONS.map((section) => (
+          <section
+            key={section.id}
+            id={section.id}
+            className="scroll-mt-24 space-y-3 rounded-xl border border-white/10 bg-black/20 p-5"
+          >
+            <h2 className="text-xl font-semibold text-white">{section.title}</h2>
+            <p className="text-sm leading-relaxed text-zinc-300">
+              {section.summary}
+            </p>
+            <dl className="grid gap-3 text-sm text-zinc-400 sm:grid-cols-2">
+              <div>
+                <dt className="text-zinc-500">Unit</dt>
+                <dd className="text-zinc-200">{section.unit}</dd>
+              </div>
+              <div>
+                <dt className="text-zinc-500">Aggregation</dt>
+                <dd className="text-zinc-200">{section.aggregation}</dd>
+              </div>
+              <div className="sm:col-span-2">
+                <dt className="text-zinc-500">Time basis</dt>
+                <dd className="text-zinc-200">{section.timeBasis}</dd>
+              </div>
+              <div className="sm:col-span-2">
+                <dt className="text-zinc-500">Source</dt>
+                <dd className="font-mono text-xs text-zinc-200">{section.source}</dd>
+              </div>
+            </dl>
+            <div className="grid gap-4 text-sm sm:grid-cols-2">
+              <div>
+                <h3 className="text-zinc-500">Inclusions</h3>
+                <ul className="mt-1 list-disc space-y-1 pl-4 text-zinc-300">
+                  {section.inclusions.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <h3 className="text-zinc-500">Exclusions</h3>
+                <ul className="mt-1 list-disc space-y-1 pl-4 text-zinc-300">
+                  {section.exclusions.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+            <div>
+              <h3 className="text-sm text-zinc-500">Known limitations</h3>
+              <ul className="mt-1 list-disc space-y-1 pl-4 text-sm text-zinc-300">
+                {section.limitations.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/DashboardPage.tsx
+++ b/components/dashboard/DashboardPage.tsx
@@ -35,6 +35,15 @@ function DashboardContent() {
             <Badge>Mainnet</Badge>
           </div>
           <FreshnessIndicator />
+            <p className="text-xs text-zinc-500">
+              <a
+                href="/methodology"
+                className="text-stellar-light hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stellar rounded-sm"
+              >
+                Metric methodology
+              </a>
+              {" · "}definitions on each KPI
+            </p>
         </div>
         <PeriodSelector />
       </header>

--- a/components/dashboard/KpiCards.tsx
+++ b/components/dashboard/KpiCards.tsx
@@ -3,36 +3,37 @@
 import { Activity, Boxes, Layers, Zap } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { MetricInfo } from "@/components/metrics/MetricInfo";
 import { useDashboard } from "@/components/dashboard/DashboardProvider";
 import { classifyFreshness } from "@/lib/freshness";
+import {
+  METRIC_DEFINITIONS,
+  type KpiMetricId,
+} from "@/lib/metrics/definitions";
 import { formatNumber, formatPercent } from "@/lib/utils";
 
 const KPI_CONFIG = [
   {
-    key: "totalOps",
-    title: "Total Operations",
+    key: "totalOps" as const satisfies KpiMetricId,
     icon: Activity,
     format: (value: number) => formatNumber(value),
   },
   {
-    key: "sorobanShare",
-    title: "Soroban Share",
+    key: "sorobanShare" as const satisfies KpiMetricId,
     icon: Zap,
     format: (value: number) => formatPercent(value),
   },
   {
-    key: "topCategory",
-    title: "Top Category",
+    key: "topCategory" as const satisfies KpiMetricId,
     icon: Layers,
     format: (value: string) => value,
   },
   {
-    key: "activeContracts",
-    title: "Active Contracts",
+    key: "activeContracts" as const satisfies KpiMetricId,
     icon: Boxes,
     format: (value: number) => formatNumber(value),
   },
-] as const;
+];
 
 export function KpiCards() {
   const { data, isLoading } = useDashboard();
@@ -68,14 +69,18 @@ export function KpiCards() {
     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 lg:gap-4">
       {KPI_CONFIG.map((item) => {
         const Icon = item.icon;
+        const metric = METRIC_DEFINITIONS[item.key];
         const kpi = data.kpis[item.key];
         const value = typeof kpi === "string" ? kpi : kpi.value;
 
         return (
           <Card key={item.key}>
-            <CardHeader className="flex-row items-center justify-between space-y-0">
-              <CardTitle>{item.title}</CardTitle>
-              <Icon className="h-4 w-4 text-stellar-light" />
+            <CardHeader className="flex-row items-start justify-between space-y-0 gap-2">
+              <div className="flex min-w-0 items-center gap-1.5">
+                <CardTitle>{metric.title}</CardTitle>
+                <MetricInfo metric={metric} />
+              </div>
+              <Icon className="mt-0.5 h-4 w-4 shrink-0 text-stellar-light" />
             </CardHeader>
             <CardContent>
               <p className="text-2xl font-semibold text-white">

--- a/components/metrics/MetricInfo.tsx
+++ b/components/metrics/MetricInfo.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import { HelpCircle } from "lucide-react";
+import type { MetricDefinition } from "@/lib/metrics/definitions";
+import { cn } from "@/lib/utils";
+
+interface MetricInfoProps {
+  metric: MetricDefinition;
+  className?: string;
+}
+
+export function MetricInfo({ metric, className }: MetricInfoProps) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const panelId = useId();
+  const titleId = useId();
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    function onPointerDown(event: MouseEvent | TouchEvent) {
+      const target = event.target as Node | null;
+      if (rootRef.current && target && !rootRef.current.contains(target)) {
+        setOpen(false);
+      }
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("touchstart", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("touchstart", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className={cn("relative", className)}>
+      <button
+        type="button"
+        className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-white/15 text-zinc-400 transition-colors hover:border-white/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stellar"
+        aria-expanded={open}
+        aria-controls={panelId}
+        aria-label={`About ${metric.title}`}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <HelpCircle className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
+
+      {open ? (
+        <div
+          id={panelId}
+          role="dialog"
+          aria-modal="false"
+          aria-labelledby={titleId}
+          className="absolute right-0 z-20 mt-2 w-[min(18rem,calc(100vw-2rem))] rounded-xl border border-white/10 bg-zinc-950/95 p-3 text-left shadow-xl backdrop-blur-sm"
+        >
+          <p id={titleId} className="text-sm font-medium text-white">
+            {metric.title}
+          </p>
+          <p className="mt-1 text-xs leading-relaxed text-zinc-300">
+            {metric.definition}
+          </p>
+          <dl className="mt-3 space-y-2 text-xs text-zinc-400">
+            <div>
+              <dt className="text-zinc-500">Unit</dt>
+              <dd className="text-zinc-200">{metric.unit}</dd>
+            </div>
+            <div>
+              <dt className="text-zinc-500">Primary limitation</dt>
+              <dd className="text-zinc-200">{metric.limitation}</dd>
+            </div>
+          </dl>
+          <a
+            href={metric.methodologyHref}
+            className="mt-3 inline-flex text-xs font-medium text-stellar-light underline-offset-2 hover:text-white hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stellar rounded-sm"
+          >
+            Methodology: {metric.methodologySection.replaceAll("-", " ")}
+          </a>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -1,0 +1,20 @@
+# LumenMap metric methodology (v0.1)
+
+Canonical counting rules for LumenMap metrics. These definitions describe how the product measures activity. They are **not** marketing claims about network health or protocol performance.
+
+The interactive copy lives at [`/methodology`](/methodology). Section anchors:
+
+| Section | Anchor |
+| --- | --- |
+| Operations | `#operations` |
+| Transactions | `#transactions` |
+| Payment volume | `#payment-volume` |
+| TVL | `#tvl` |
+| Active accounts | `#active-accounts` |
+| Active contracts | `#active-contracts` |
+| Soroban share | `#soroban-share` |
+| Top category | `#top-category` |
+| Time basis | `#time-basis` |
+| Hubble freshness | `#hubble-freshness` |
+
+Source of truth for section bodies: [`lib/metrics/methodology.ts`](../lib/metrics/methodology.ts).

--- a/lib/metrics/definitions.test.ts
+++ b/lib/metrics/definitions.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  DASHBOARD_METRIC_IDS,
+  METRIC_DEFINITIONS,
+  getMetricDefinition,
+} from "@/lib/metrics/definitions";
+import {
+  METHODOLOGY_SECTIONS,
+  getMethodologySection,
+  methodologyPath,
+} from "@/lib/metrics/methodology";
+
+describe("dashboard metric definitions", () => {
+  it("defines every selectable KPI metric", () => {
+    assert.deepEqual(DASHBOARD_METRIC_IDS.sort(), [
+      "activeContracts",
+      "sorobanShare",
+      "topCategory",
+      "totalOps",
+    ]);
+  });
+
+  it("exposes definition, unit, limitation, and methodology target", () => {
+    for (const id of DASHBOARD_METRIC_IDS) {
+      const metric = getMetricDefinition(id);
+      assert.ok(metric.definition.length > 20, id);
+      assert.ok(metric.unit.length > 0, id);
+      assert.ok(metric.limitation.length > 10, id);
+      assert.equal(
+        metric.methodologyHref,
+        methodologyPath(metric.methodologySection),
+      );
+      assert.equal(
+        metric.methodologyHref,
+        `/methodology#${metric.methodologySection}`,
+      );
+      // Ensure the target section exists.
+      const section = getMethodologySection(metric.methodologySection);
+      assert.equal(section.id, metric.methodologySection);
+      assert.ok(section.unit.length > 0);
+      assert.ok(section.limitations.length > 0);
+    }
+  });
+
+  it("does not use marketing claims as methodology copy", () => {
+    const banned = [/best[ -]?in[ -]?class/i, /unmatched/i, /guaranteed/i];
+    for (const metric of Object.values(METRIC_DEFINITIONS)) {
+      for (const pattern of banned) {
+        assert.equal(pattern.test(metric.definition), false, metric.id);
+        assert.equal(pattern.test(metric.limitation), false, metric.id);
+      }
+    }
+    for (const section of METHODOLOGY_SECTIONS) {
+      for (const pattern of banned) {
+        assert.equal(pattern.test(section.summary), false, section.id);
+      }
+    }
+  });
+});
+
+describe("methodology sections", () => {
+  it("covers operations, transactions, volume, TVL, and active entities", () => {
+    const ids = METHODOLOGY_SECTIONS.map((section) => section.id);
+    const required = [
+      "operations",
+      "transactions",
+      "payment-volume",
+      "tvl",
+      "active-accounts",
+      "active-contracts",
+    ] as const;
+    for (const id of required) {
+      assert.ok(ids.includes(id), id);
+    }
+  });
+});

--- a/lib/metrics/definitions.ts
+++ b/lib/metrics/definitions.ts
@@ -1,0 +1,77 @@
+import {
+  methodologyPath,
+  type MethodologySectionId,
+} from "@/lib/metrics/methodology";
+
+export type KpiMetricId =
+  | "totalOps"
+  | "sorobanShare"
+  | "topCategory"
+  | "activeContracts";
+
+export interface MetricDefinition {
+  id: KpiMetricId;
+  title: string;
+  /** One or two sentences at the point of use. */
+  definition: string;
+  unit: string;
+  /** Primary limitation / exclusion called out inline. */
+  limitation: string;
+  methodologySection: MethodologySectionId;
+  methodologyHref: string;
+}
+
+export const METRIC_DEFINITIONS: Record<KpiMetricId, MetricDefinition> = {
+  totalOps: {
+    id: "totalOps",
+    title: "Total Operations",
+    definition:
+      "Number of closed Stellar operations in the selected period, summed across operation types.",
+    unit: "operations (count)",
+    limitation:
+      "Not a transaction count; Hubble lag can understate the latest partial day.",
+    methodologySection: "operations",
+    methodologyHref: methodologyPath("operations"),
+  },
+  sorobanShare: {
+    id: "sorobanShare",
+    title: "Soroban Share",
+    definition:
+      "Percentage of period operations whose type maps to the Soroban category.",
+    unit: "percent of operations",
+    limitation:
+      "Uses LumenMap category mapping; undefined when total operations are zero.",
+    methodologySection: "soroban-share",
+    methodologyHref: methodologyPath("soroban-share"),
+  },
+  topCategory: {
+    id: "topCategory",
+    title: "Top Category",
+    definition:
+      "Activity category with the largest operation count in the selected period.",
+    unit: "category label",
+    limitation:
+      "Categorical ranking of grouped types, not asset volume or unique users.",
+    methodologySection: "top-category",
+    methodologyHref: methodologyPath("top-category"),
+  },
+  activeContracts: {
+    id: "activeContracts",
+    title: "Active Contracts",
+    definition:
+      "Count of Soroban contracts with activity returned for the period contract query.",
+    unit: "contracts (count)",
+    limitation:
+      "Currently derived from a top-200 leaderboard result, so busy periods can undercount.",
+    methodologySection: "active-contracts",
+    methodologyHref: methodologyPath("active-contracts"),
+  },
+};
+
+export const DASHBOARD_METRIC_IDS = Object.keys(
+  METRIC_DEFINITIONS,
+) as KpiMetricId[];
+
+export function getMetricDefinition(id: KpiMetricId): MetricDefinition {
+  return METRIC_DEFINITIONS[id];
+}

--- a/lib/metrics/methodology.ts
+++ b/lib/metrics/methodology.ts
@@ -1,0 +1,238 @@
+/**
+ * Canonical metric methodology (v0.1).
+ * Inline UI definitions link to these section ids via /methodology#<id>.
+ */
+
+export const METHODOLOGY_VERSION = "0.1";
+
+export type MethodologySectionId =
+  | "operations"
+  | "transactions"
+  | "payment-volume"
+  | "tvl"
+  | "active-accounts"
+  | "active-contracts"
+  | "soroban-share"
+  | "top-category"
+  | "time-basis"
+  | "hubble-freshness";
+
+export interface MethodologySection {
+  id: MethodologySectionId;
+  title: string;
+  summary: string;
+  unit: string;
+  aggregation: string;
+  timeBasis: string;
+  source: string;
+  inclusions: string[];
+  exclusions: string[];
+  limitations: string[];
+}
+
+export const METHODOLOGY_SECTIONS: MethodologySection[] = [
+  {
+    id: "operations",
+    title: "Operations",
+    summary:
+      "Count of Stellar operations closed in the selected period, grouped by operation type.",
+    unit: "operations (count)",
+    aggregation: "COUNT(*) of operations; dashboard totals sum type counts.",
+    timeBasis:
+      "Inclusive wall-clock period using the server period resolver (Today, last 7/30 days, or calendar month).",
+    source:
+      "`crypto-stellar.crypto_stellar_dbt.enriched_history_operations.type_string` filtered by `closed_at`.",
+    inclusions: [
+      "All operation types present in Hubble for the period",
+      "Soroban and classic operations",
+    ],
+    exclusions: [
+      "Failed or non-closed operations not present in the enriched closed-at feed",
+      "Mempool / unconfirmed activity",
+    ],
+    limitations: [
+      "This is not a transaction count; one transaction may contain multiple operations.",
+      "Hubble batch lag can understate the most recent partial day.",
+    ],
+  },
+  {
+    id: "transactions",
+    title: "Transactions",
+    summary:
+      "Count of distinct transactions that closed in the selected period. Not currently shown as a dashboard KPI.",
+    unit: "transactions (count)",
+    aggregation: "COUNT(DISTINCT transaction hash / id) over closed transactions.",
+    timeBasis: "Same selected period bounds as operations.",
+    source:
+      "Hubble transaction / operation linkage tables (planned surface; not queried by the current KPI cards).",
+    inclusions: ["Closed transactions in the period"],
+    exclusions: [
+      "Operations within a transaction are not counted here",
+      "Unconfirmed submissions",
+    ],
+    limitations: [
+      "Transaction count and operation count are different metrics and must not be compared as equivalents.",
+      "Not exposed in the current dashboard UI.",
+    ],
+  },
+  {
+    id: "payment-volume",
+    title: "Payment volume",
+    summary:
+      "Asset-denominated payment amounts moved in the period. Not currently shown as a dashboard KPI.",
+    unit: "asset units (for example XLM or USDC), never a mixed-asset total without normalization",
+    aggregation:
+      "SUM of payment amounts per asset code/issuer. Cross-asset totals require an explicit FX normalization rule.",
+    timeBasis: "Same selected period bounds as operations.",
+    source: "Hubble payment amount fields on enriched payment operations (planned).",
+    inclusions: ["Payment and path-payment style transfers when enabled"],
+    exclusions: [
+      "Non-payment operation types",
+      "Unnormalized multi-asset rollups",
+    ],
+    limitations: [
+      "LumenMap does not present a single cross-asset volume total without a documented normalization method.",
+      "Not exposed in the current dashboard UI.",
+    ],
+  },
+  {
+    id: "tvl",
+    title: "TVL (total value locked)",
+    summary:
+      "Point-in-time estimate of value committed to protocols at a snapshot. Not currently shown as a dashboard KPI.",
+    unit: "quoted currency at snapshot time (for example USD), after documented pricing",
+    aggregation:
+      "Sum of protocol balances at a timestamp; protocol adapters must state double-counting rules.",
+    timeBasis: "Point-in-time snapshot, not a period sum.",
+    source: "Protocol-specific reserve / pool state (planned; no default adapter yet).",
+    inclusions: ["Balances explicitly held by supported protocol contracts"],
+    exclusions: [
+      "Wallet balances not locked in a protocol",
+      "Unpriced or unverifiable reserves",
+    ],
+    limitations: [
+      "TVL is sensitive to oracle price choice and can double-count assets bridged across protocols.",
+      "Not exposed in the current dashboard UI.",
+    ],
+  },
+  {
+    id: "active-accounts",
+    title: "Active accounts",
+    summary:
+      "Distinct account public keys that sourced qualifying operations in the period. Not currently a KPI card.",
+    unit: "accounts (distinct count)",
+    aggregation: "COUNT(DISTINCT op_source_account) for selected operation types.",
+    timeBasis: "Same selected period bounds as operations.",
+    source:
+      "`enriched_history_operations.op_source_account` (leaderboard queries today return top-N per type, not the full distinct set).",
+    inclusions: ["Accounts that appear as operation source accounts"],
+    exclusions: [
+      "Accounts that only receive payments without sourcing ops in the filtered set",
+      "Contract IDs",
+    ],
+    limitations: [
+      "The treemap account list is top-N capped per operation type and is not the full active-account universe.",
+      "Not exposed as a dedicated KPI card yet.",
+    ],
+  },
+  {
+    id: "active-contracts",
+    title: "Active contracts",
+    summary:
+      "Soroban contracts with fee / invoke activity in the period, as returned by the contract activity query.",
+    unit: "contracts (count)",
+    aggregation:
+      "Number of contract IDs returned by the period contract leaderboard query after grouping.",
+    timeBasis: "Same selected period bounds as operations.",
+    source:
+      "`crypto-stellar.crypto_stellar_dbt.hourly_soroban_fee_agg_contract` grouped by `contract_id` with null/empty IDs removed.",
+    inclusions: ["Contracts with non-empty contract_id and activity in-range"],
+    exclusions: ["Null or empty contract IDs", "Non-contract classic accounts"],
+    limitations: [
+      "The current KPI uses the leaderboard result length, which is capped (top 200), so busy periods can undercount.",
+      "Hubble lag can delay the newest hours.",
+    ],
+  },
+  {
+    id: "soroban-share",
+    title: "Soroban share",
+    summary:
+      "Share of period operations whose type maps to the Soroban category.",
+    unit: "percent of operations",
+    aggregation:
+      "(Soroban-category operation count / total operation count) × 100.",
+    timeBasis: "Same selected period bounds as operations.",
+    source:
+      "Derived from operation type totals using LumenMap category mapping (`invoke_host_function`, footprint ops → Soroban).",
+    inclusions: ["Operations mapped to the Soroban category"],
+    exclusions: ["Classic payment, DEX, trustline, and account categories"],
+    limitations: [
+      "Category mapping is product-defined; raw Hubble types remain available in treemap drill-down.",
+      "Undefined when total operations are zero.",
+    ],
+  },
+  {
+    id: "top-category",
+    title: "Top category",
+    summary:
+      "The LumenMap activity category with the largest operation count in the period.",
+    unit: "category label",
+    aggregation: "Argmax of summed operation counts across category groups.",
+    timeBasis: "Same selected period bounds as operations.",
+    source: "Derived from operation type totals and `TYPE_TO_GROUP` mapping.",
+    inclusions: [
+      "Soroban, Payments, DEX, Trustlines, Account Operations, Other",
+    ],
+    exclusions: ["Entity-level rankings (accounts/contracts)"],
+    limitations: [
+      "Ties resolve by sort order of aggregated totals; label is categorical, not a numeric volume.",
+    ],
+  },
+  {
+    id: "time-basis",
+    title: "Time basis and partial periods",
+    summary:
+      "How LumenMap bounds Today, multi-day windows, and the calendar month.",
+    unit: "n/a",
+    aggregation: "n/a",
+    timeBasis:
+      "Period start/end come from the dashboard period control. The current day or month can be partial until the period ends.",
+    source: "`lib/periods.ts` period resolver used by `/api/activity`.",
+    inclusions: ["Closed operations with `closed_at` inside the resolved bounds"],
+    exclusions: ["Activity outside the selected bounds"],
+    limitations: [
+      "Partial current periods are expected to grow as new Hubble batches arrive.",
+      "Host timezone can affect local period boundaries until an explicit UTC policy is enforced.",
+    ],
+  },
+  {
+    id: "hubble-freshness",
+    title: "Hubble freshness",
+    summary:
+      "Analytics numbers follow Hubble’s batch refresh, not sub-second chain tip state.",
+    unit: "n/a",
+    aggregation: "n/a",
+    timeBasis: "Intraday Hubble batches; exact lag varies.",
+    source: "Stellar Hubble BigQuery datasets.",
+    inclusions: ["Data present in the Hubble tables at query time"],
+    exclusions: ["Unindexed tip activity"],
+    limitations: [
+      "Recent intervals can under-report until the next Hubble refresh.",
+      "API responses may be cached for several minutes server-side.",
+    ],
+  },
+];
+
+export function getMethodologySection(
+  id: MethodologySectionId,
+): MethodologySection {
+  const section = METHODOLOGY_SECTIONS.find((entry) => entry.id === id);
+  if (!section) {
+    throw new Error(`Unknown methodology section: ${id}`);
+  }
+  return section;
+}
+
+export function methodologyPath(id: MethodologySectionId): string {
+  return `/methodology#${id}`;
+}


### PR DESCRIPTION
Introduce a canonical methodology document and /methodology page, then surface concise KPI definitions with unit, primary limitation, and accessible links to the matching section. Closes #59 