### PR TITLE
Expired exntries

### DIFF
--- a/lib/hubble/cache.test.ts
+++ b/lib/hubble/cache.test.ts
@@ -5,6 +5,8 @@ import {
   setCache,
   getCached,
   clearCache,
+  setClock,
+  pruneCache,
   DEFAULT_CACHE_TTL_SECONDS,
   MIN_CACHE_TTL_SECONDS,
   MAX_CACHE_TTL_SECONDS,
@@ -104,5 +106,67 @@ describe("in-memory cache behavior", () => {
 
   test("getCached returns null for non-existent keys", () => {
     assert.equal(getCached("nonexistent"), null);
+  });
+});
+
+
+describe("proactive expired-entry pruning", () => {
+  beforeEach(() => {
+    clearCache();
+    setClock(() => Date.now());
+  });
+
+  test("setCache prunes expired entries from previous writes", () => {
+    setClock(() => 0);
+    setCache("a", 1, 10);
+    setCache("b", 2, 100);
+
+    setClock(() => 20_000);
+    setCache("c", 3, 100);
+
+    assert.equal(getCached("a"), null);
+    assert.equal(getCached<number>("b"), 2);
+    assert.equal(getCached<number>("c"), 3);
+  });
+
+  test("pruneCache removes only expired entries", () => {
+    setClock(() => 0);
+    setCache("a", 1, 10);
+    setCache("b", 2, 20);
+    setCache("c", 3, 30);
+
+    setClock(() => 15_000);
+    pruneCache();
+
+    assert.equal(getCached("a"), null);
+    assert.equal(getCached<number>("b"), 2);
+    assert.equal(getCached<number>("c"), 3);
+  });
+
+  test("pruneCache removes nothing when all entries are fresh", () => {
+    setClock(() => 0);
+    setCache("a", 1, 100);
+    setCache("b", 2, 200);
+
+    pruneCache();
+
+    assert.equal(getCached<number>("a"), 1);
+    assert.equal(getCached<number>("b"), 2);
+  });
+
+  test("pruneCache handles an empty cache", () => {
+    assert.doesNotThrow(() => pruneCache());
+  });
+
+  test("unexpired entries survive pruning after controlled clock advance", () => {
+    setClock(() => 0);
+    setCache("fresh", "ok", 60);
+    setCache("stale", "bye", 5);
+
+    setClock(() => 10_000);
+    pruneCache();
+
+    assert.equal(getCached("stale"), null);
+    assert.equal(getCached<string>("fresh"), "ok");
   });
 });

--- a/lib/hubble/cache.ts
+++ b/lib/hubble/cache.ts
@@ -24,7 +24,15 @@ export function parseCacheTtl(input?: unknown): number {
   return Math.floor(num);
 }
 
+type Clock = () => number;
+
 const cache = new Map<string, { data: unknown; expires: number }>();
+let now: Clock = () => Date.now();
+
+/** Inject a clock for deterministic cache expiry tests. */
+export function setClock(clock: Clock): void {
+  now = clock;
+}
 
 export function clearCache(): void {
   cache.clear();
@@ -36,7 +44,7 @@ export function getCached<T>(key: string): T | null {
     return null;
   }
 
-  if (Date.now() > entry.expires) {
+  if (now() > entry.expires) {
     cache.delete(key);
     return null;
   }
@@ -55,7 +63,20 @@ export function setCache(
 
   cache.set(key, {
     data,
-    expires: Date.now() + validTtl * 1000,
+    expires: now() + validTtl * 1000,
   });
+  pruneCache();
 }
 
+/**
+ * Remove expired entries even when their keys are never read again.
+ * Invoked on writes so work stays bounded to request-time paths.
+ */
+export function pruneCache(): void {
+  const currentTime = now();
+  for (const [key, entry] of cache) {
+    if (currentTime > entry.expires) {
+      cache.delete(key);
+    }
+  }
+}


### PR DESCRIPTION
Closes #39

Closes #39

All 9 tests pass. The implementation already satisfies every acceptance criterion:
lib/hubble/cache.ts — setCache() calls pruneCache() after every write, which iterates all entries and deletes any where now() > entry.expires. An injectable clock (setClock) enables deterministic testing without wall-clock time. No timers or intervals.
lib/hubble/cache.test.ts — 9 tests covering:
- pruneCache removes only expired entries, preserves fresh ones, handles empty cache
- setCache triggers pruning so expired entries from prior writes are removed
- getCached returns null for expired entries (deletes on read — preserved existing behavior)
- Typed reads/writes unchanged