### PR TITLE
Add timeout

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -46,24 +46,6 @@ export const TYPE_TO_GROUP: Record<string, string> = {
   restore_footprint: "soroban",
 };
 
-export const ACCOUNT_QUERY_TYPES = [
-  "payment",
-  "path_payment_strict_receive",
-  "path_payment_strict_send",
-  "manage_buy_offer",
-  "manage_sell_offer",
-  "create_passive_sell_offer",
-  "change_trust",
-  "create_account",
-  "liquidity_pool_deposit",
-  "liquidity_pool_withdraw",
-];
-
-export const TOP_ACCOUNTS_PER_TYPE = 70;
-export const TOP_CONTRACT_LIMIT = 200;
-export const TOP_SOROBAN_FUNCTIONS = 100;
-export const TOP_CONTRACTS_PER_FUNCTION = 70;
-
 export const TREEMAP_VIEWS = [
   {
     id: "events",

--- a/lib/hubble/activity.ts
+++ b/lib/hubble/activity.ts
@@ -1,11 +1,11 @@
 import { getBigQueryClient } from "@/lib/hubble/client";
 import { getCached, setCache } from "@/lib/hubble/cache";
 import {
+  ACCOUNT_QUERY_TYPES,
   accountQuery,
   accountMetadataQuery,
   categoryQuery,
   contractQuery,
-  getAccountQueryTypes,
   mapAccountMetadataRows,
   mapAccountRows,
   mapCategoryRows,
@@ -60,7 +60,7 @@ async function fetchFromHubble(
     runQuery<Record<string, unknown>>(contractQuery, params),
     runQuery<Record<string, unknown>>(accountQuery, {
       ...params,
-      types: getAccountQueryTypes(),
+      types: ACCOUNT_QUERY_TYPES,
     }),
     runQuery<Record<string, unknown>>(sorobanFunctionQuery, params),
     runQuery<Record<string, unknown>>(sorobanFunctionContractQuery, params),

--- a/lib/hubble/activity.ts
+++ b/lib/hubble/activity.ts
@@ -1,4 +1,4 @@
-import { getBigQueryClient } from "@/lib/hubble/client";
+import { executeQuery } from "@/lib/hubble/executor";
 import { getCached, setCache } from "@/lib/hubble/cache";
 import {
   ACCOUNT_QUERY_TYPES,
@@ -26,23 +26,6 @@ import {
 import { resolvePeriod } from "@/lib/periods";
 import type { ActivityResponse, Period } from "@/lib/types";
 
-async function runQuery<T>(
-  query: string,
-  params: Record<string, unknown>,
-): Promise<T[]> {
-  const client = getBigQueryClient();
-  if (!client) {
-    throw new Error("BigQuery client is not configured");
-  }
-
-  const [rows] = await client.query({
-    query,
-    params,
-  });
-
-  return rows as T[];
-}
-
 async function fetchFromHubble(
   start: string,
   end: string,
@@ -56,14 +39,14 @@ async function fetchFromHubble(
     sorobanFunctionRows,
     sorobanFunctionContractRows,
   ] = await Promise.all([
-    runQuery<Record<string, unknown>>(categoryQuery, params),
-    runQuery<Record<string, unknown>>(contractQuery, params),
-    runQuery<Record<string, unknown>>(accountQuery, {
+    executeQuery<Record<string, unknown>>(categoryQuery, params),
+    executeQuery<Record<string, unknown>>(contractQuery, params),
+    executeQuery<Record<string, unknown>>(accountQuery, {
       ...params,
       types: ACCOUNT_QUERY_TYPES,
     }),
-    runQuery<Record<string, unknown>>(sorobanFunctionQuery, params),
-    runQuery<Record<string, unknown>>(sorobanFunctionContractQuery, params),
+    executeQuery<Record<string, unknown>>(sorobanFunctionQuery, params),
+    executeQuery<Record<string, unknown>>(sorobanFunctionContractQuery, params),
   ]);
 
   return {
@@ -82,7 +65,7 @@ async function fetchHomeDomains(ids: string[]) {
     return {};
   }
 
-  const rows = await runQuery<Record<string, unknown>>(accountMetadataQuery, {
+  const rows = await executeQuery<Record<string, unknown>>(accountMetadataQuery, {
     ids,
   });
 

--- a/lib/hubble/cache.test.ts
+++ b/lib/hubble/cache.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getCached, setCache, setClock, pruneCache } from "./cache";
+
+beforeEach(() => {
+  setClock(() => Date.now());
+});
+
+describe("getCached", () => {
+  it("returns null for a missing key", () => {
+    expect(getCached("nope")).toBeNull();
+  });
+
+  it("returns typed data for a valid entry", () => {
+    setCache("str", "hello");
+    expect(getCached<string>("str")).toBe("hello");
+  });
+
+  it("returns null for an expired entry and deletes it", () => {
+    setClock(() => 0);
+    setCache("k", "v", 10);
+
+    setClock(() => 15_000);
+    expect(getCached("k")).toBeNull();
+  });
+});
+
+describe("setCache", () => {
+  it("stores an entry with the default TTL", () => {
+    setClock(() => 1000);
+    setCache("k", 42);
+    expect(getCached<number>("k")).toBe(42);
+  });
+
+  it("accepts a custom TTL in seconds", () => {
+    setClock(() => 0);
+    setCache("k", "v", 60);
+    setClock(() => 59_000);
+    expect(getCached("k")).toBe("v");
+    setClock(() => 61_000);
+    expect(getCached("k")).toBeNull();
+  });
+
+  it("triggers pruning so expired entries from previous writes are removed", () => {
+    setClock(() => 0);
+    setCache("a", 1, 10);
+    setCache("b", 2, 100);
+
+    setClock(() => 20_000);
+    setCache("c", 3);
+
+    expect(getCached("a")).toBeNull();
+    expect(getCached("b")).toBe(2);
+    expect(getCached("c")).toBe(3);
+  });
+});
+
+describe("pruneCache", () => {
+  it("removes only expired entries", () => {
+    setClock(() => 0);
+    setCache("a", 1, 10);
+    setCache("b", 2, 20);
+    setCache("c", 3, 30);
+
+    setClock(() => 15_000);
+    pruneCache();
+
+    expect(getCached("a")).toBeNull();
+    expect(getCached("b")).toBe(2);
+    expect(getCached("c")).toBe(3);
+  });
+
+  it("removes nothing when all entries are fresh", () => {
+    setClock(() => 0);
+    setCache("a", 1, 100);
+    setCache("b", 2, 200);
+
+    pruneCache();
+
+    expect(getCached("a")).toBe(1);
+    expect(getCached("b")).toBe(2);
+  });
+
+  it("handles an empty cache", () => {
+    expect(() => pruneCache()).not.toThrow();
+  });
+});

--- a/lib/hubble/cache.ts
+++ b/lib/hubble/cache.ts
@@ -1,4 +1,11 @@
+type Clock = () => number;
+
 const cache = new Map<string, { data: unknown; expires: number }>();
+let now: Clock = () => Date.now();
+
+export function setClock(clock: Clock): void {
+  now = clock;
+}
 
 export function getCached<T>(key: string): T | null {
   const entry = cache.get(key);
@@ -6,7 +13,7 @@ export function getCached<T>(key: string): T | null {
     return null;
   }
 
-  if (Date.now() > entry.expires) {
+  if (now() > entry.expires) {
     cache.delete(key);
     return null;
   }
@@ -21,6 +28,16 @@ export function setCache(
 ): void {
   cache.set(key, {
     data,
-    expires: Date.now() + ttlSeconds * 1000,
+    expires: now() + ttlSeconds * 1000,
   });
+  pruneCache();
+}
+
+export function pruneCache(): void {
+  const currentTime = now();
+  for (const [key, entry] of cache) {
+    if (currentTime > entry.expires) {
+      cache.delete(key);
+    }
+  }
 }

--- a/lib/hubble/executor.test.ts
+++ b/lib/hubble/executor.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  executeQuery,
+  HubError,
+  setClientProvider,
+  DEFAULT_QUERY_TIMEOUT_MS,
+} from "./executor";
+
+interface FakeJob {
+  cancel(): Promise<unknown>;
+  getQueryResults(): Promise<[unknown[], unknown]>;
+}
+
+interface FakeClient {
+  createQueryJob(
+    opts: { query: string; params: Record<string, unknown> },
+  ): Promise<[FakeJob | null, unknown]>;
+}
+
+function createFakeClient(options?: {
+  delayMs?: number;
+  cancelFails?: boolean;
+  noJob?: boolean;
+}): { client: FakeClient; cancelCalled(): boolean } {
+  const { delayMs = 0, cancelFails = false, noJob = false } = options ?? {};
+
+  let cancelCalled = false;
+
+  const job: FakeJob = {
+    cancel: async () => {
+      cancelCalled = true;
+      if (cancelFails) {
+        throw new Error("Simulated cancel failure");
+      }
+    },
+    getQueryResults: async () => {
+      await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+      return [[{ id: 1 }], {}];
+    },
+  };
+
+  const client: FakeClient = {
+    createQueryJob: async () => {
+      if (noJob) {
+        return [null, {}];
+      }
+      return [job, {}];
+    },
+  };
+
+  return {
+    client,
+    cancelCalled: () => cancelCalled,
+  };
+}
+
+beforeEach(() => {
+  setClientProvider(() => null);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("executeQuery", () => {
+  it("returns rows when query completes before deadline", async () => {
+    const { client } = createFakeClient({ delayMs: 1 });
+    setClientProvider(() => client as never);
+
+    const result = await executeQuery<{ id: number }>("SELECT 1", {});
+
+    expect(result).toEqual([{ id: 1 }]);
+  });
+
+  it("rejects with TIMEOUT when query exceeds deadline and cancels the job", async () => {
+    const { client, cancelCalled } = createFakeClient({ delayMs: 200 });
+    setClientProvider(() => client as never);
+
+    const promise = executeQuery("SELECT 1", {}, 20);
+
+    await expect(promise).rejects.toThrow(HubError);
+    await expect(promise).rejects.toMatchObject({ code: "TIMEOUT" });
+    expect(cancelCalled()).toBe(true);
+  });
+
+  it("rejects with TIMEOUT when there is no job identity", async () => {
+    const { client } = createFakeClient({ noJob: true });
+    setClientProvider(() => client as never);
+
+    const promise = executeQuery("SELECT 1", {}, 10);
+
+    await expect(promise).rejects.toMatchObject({ code: "TIMEOUT" });
+  });
+
+  it("rejects with TIMEOUT even when cancellation fails", async () => {
+    const { client, cancelCalled } = createFakeClient({
+      delayMs: 200,
+      cancelFails: true,
+    });
+    setClientProvider(() => client as never);
+
+    const promise = executeQuery("SELECT 1", {}, 20);
+
+    await expect(promise).rejects.toMatchObject({ code: "TIMEOUT" });
+    expect(cancelCalled()).toBe(true);
+  });
+
+  it("discards late completion after timeout", async () => {
+    const { client, cancelCalled } = createFakeClient({ delayMs: 100 });
+    setClientProvider(() => client as never);
+
+    const promise = executeQuery("SELECT 1", {}, 10);
+
+    await expect(promise).rejects.toMatchObject({ code: "TIMEOUT" });
+    expect(cancelCalled()).toBe(true);
+
+    // Wait for the late query to finish — it should be discarded
+    await new Promise<void>((resolve) => setTimeout(resolve, 200));
+
+    // Promise state is unchanged
+    await expect(promise).rejects.toMatchObject({ code: "TIMEOUT" });
+  });
+
+  it("rejects with VALIDATION when no client is configured", async () => {
+    const promise = executeQuery("SELECT 1", {});
+    await expect(promise).rejects.toThrow(HubError);
+    await expect(promise).rejects.toMatchObject({ code: "VALIDATION" });
+  });
+
+  it("rejects with PROVIDER when createQueryJob fails", async () => {
+    const failingClient = {
+      createQueryJob: async () => {
+        throw new Error("Network error");
+      },
+    };
+    setClientProvider(() => failingClient as never);
+
+    const promise = executeQuery("SELECT 1", {});
+    await expect(promise).rejects.toMatchObject({ code: "PROVIDER" });
+  });
+
+  it("uses the default timeout constant", () => {
+    expect(DEFAULT_QUERY_TIMEOUT_MS).toBe(30_000);
+  });
+});

--- a/lib/hubble/executor.ts
+++ b/lib/hubble/executor.ts
@@ -1,0 +1,82 @@
+import { getBigQueryClient } from "./client";
+
+export class HubError extends Error {
+  constructor(
+    message: string,
+    public readonly code: "TIMEOUT" | "CANCELLATION" | "PROVIDER" | "VALIDATION",
+  ) {
+    super(message);
+    this.name = "HubError";
+  }
+}
+
+type ClientProvider = () => ReturnType<typeof getBigQueryClient>;
+let provider: ClientProvider = getBigQueryClient;
+
+export function setClientProvider(p: ClientProvider): void {
+  provider = p;
+}
+
+interface QueryJob {
+  cancel(): Promise<unknown>;
+  getQueryResults(): Promise<[unknown[], unknown]>;
+}
+
+export const DEFAULT_QUERY_TIMEOUT_MS = 30_000;
+
+export async function executeQuery<T>(
+  query: string,
+  params: Record<string, unknown>,
+  timeoutMs: number = DEFAULT_QUERY_TIMEOUT_MS,
+): Promise<T[]> {
+  const client = provider();
+  if (!client) {
+    throw new HubError("BigQuery client is not configured", "VALIDATION");
+  }
+
+  let job: QueryJob | null;
+  try {
+    const result = await client.createQueryJob({ query, params });
+    job = (result[0] as unknown as QueryJob | undefined) ?? null;
+  } catch (err) {
+    throw new HubError(
+      err instanceof Error ? err.message : "Failed to create query job",
+      "PROVIDER",
+    );
+  }
+
+  return new Promise<T[]>((resolve, reject) => {
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+
+      if (job) {
+        job.cancel().catch(() => {});
+      }
+
+      reject(new HubError("Query timed out", "TIMEOUT"));
+    }, timeoutMs);
+
+    if (!job) {
+      return;
+    }
+
+    job.getQueryResults()
+      .then(
+        ([rows]) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          resolve(rows as T[]);
+        },
+      )
+      .catch((err: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(new HubError(err.message, "PROVIDER"));
+      });
+  });
+}

--- a/lib/hubble/queries.ts
+++ b/lib/hubble/queries.ts
@@ -1,10 +1,16 @@
 import {
   ACCOUNT_QUERY_TYPES,
+  accountMetadataQuery,
+  accountQuery,
+  categoryQuery,
+  contractQuery,
+  sorobanFunctionContractQuery,
+  sorobanFunctionQuery,
   TOP_ACCOUNTS_PER_TYPE,
   TOP_CONTRACT_LIMIT,
   TOP_CONTRACTS_PER_FUNCTION,
   TOP_SOROBAN_FUNCTIONS,
-} from "@/lib/constants";
+} from "./shared-queries.mjs";
 import type {
   AccountRow,
   CategoryRow,
@@ -13,107 +19,25 @@ import type {
   SorobanFunctionRow,
 } from "@/lib/types";
 
+export {
+  ACCOUNT_QUERY_TYPES,
+  accountMetadataQuery,
+  accountQuery,
+  categoryQuery,
+  contractQuery,
+  queryRegistry,
+  sorobanFunctionContractQuery,
+  sorobanFunctionQuery,
+  TOP_ACCOUNTS_PER_TYPE,
+  TOP_CONTRACT_LIMIT,
+  TOP_CONTRACTS_PER_FUNCTION,
+  TOP_SOROBAN_FUNCTIONS,
+} from "./shared-queries.mjs";
+
 export interface QueryParams {
   start: string;
   end: string;
 }
-
-export const categoryQuery = `
-SELECT
-  type_string,
-  COUNT(*) AS op_count
-FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations\`
-WHERE closed_at BETWEEN @start AND @end
-GROUP BY type_string
-ORDER BY op_count DESC
-`;
-
-export const contractQuery = `
-SELECT
-  contract_id,
-  SUM(txn_count) AS op_count
-FROM \`crypto-stellar.crypto_stellar_dbt.hourly_soroban_fee_agg_contract\`
-WHERE hour_agg BETWEEN @start AND @end
-  AND contract_id IS NOT NULL
-  AND contract_id != ''
-GROUP BY contract_id
-ORDER BY op_count DESC
-LIMIT ${TOP_CONTRACT_LIMIT}
-`;
-
-export const accountQuery = `
-WITH ranked AS (
-  SELECT
-    op_source_account AS account_id,
-    type_string,
-    COUNT(*) AS op_count,
-    ROW_NUMBER() OVER (
-      PARTITION BY type_string
-      ORDER BY COUNT(*) DESC
-    ) AS rank
-  FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations\`
-  WHERE closed_at BETWEEN @start AND @end
-    AND type_string IN UNNEST(@types)
-  GROUP BY account_id, type_string
-)
-SELECT account_id, type_string, op_count
-FROM ranked
-WHERE rank <= ${TOP_ACCOUNTS_PER_TYPE}
-ORDER BY type_string, op_count DESC
-`;
-
-export const sorobanFunctionQuery = `
-WITH labeled AS (
-  SELECT
-    CASE
-      WHEN soroban_operation_type = 'invoke_contract'
-        AND parameters_decoded[SAFE_OFFSET(1)].type = 'Sym'
-      THEN parameters_decoded[SAFE_OFFSET(1)].value
-      ELSE soroban_operation_type
-    END AS function_name
-  FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations_soroban\`
-  WHERE closed_at BETWEEN @start AND @end
-)
-SELECT
-  function_name,
-  COUNT(*) AS op_count
-FROM labeled
-WHERE function_name IS NOT NULL AND function_name != ''
-GROUP BY function_name
-ORDER BY op_count DESC
-LIMIT ${TOP_SOROBAN_FUNCTIONS}
-`;
-
-export const sorobanFunctionContractQuery = `
-WITH aggregated AS (
-  SELECT
-    parameters_decoded[SAFE_OFFSET(1)].value AS function_name,
-    contract_id,
-    COUNT(*) AS op_count
-  FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations_soroban\`
-  WHERE closed_at BETWEEN @start AND @end
-    AND soroban_operation_type = 'invoke_contract'
-    AND parameters_decoded[SAFE_OFFSET(1)].type = 'Sym'
-    AND contract_id IS NOT NULL
-    AND contract_id != ''
-  GROUP BY function_name, contract_id
-),
-ranked AS (
-  SELECT
-    function_name,
-    contract_id,
-    op_count,
-    ROW_NUMBER() OVER (
-      PARTITION BY function_name
-      ORDER BY op_count DESC
-    ) AS rank
-  FROM aggregated
-)
-SELECT function_name, contract_id, op_count
-FROM ranked
-WHERE rank <= ${TOP_CONTRACTS_PER_FUNCTION}
-ORDER BY function_name, op_count DESC
-`;
 
 export function getAccountQueryTypes(): string[] {
   return ACCOUNT_QUERY_TYPES;
@@ -167,16 +91,6 @@ export function mapSorobanFunctionContractRows(
     op_count: Number(row.op_count),
   }));
 }
-
-export const accountMetadataQuery = `
-SELECT
-  account_id,
-  home_domain
-FROM \`crypto-stellar.crypto_stellar_dbt.accounts_current\`
-WHERE account_id IN UNNEST(@ids)
-  AND home_domain IS NOT NULL
-  AND home_domain != ''
-`;
 
 export function mapAccountMetadataRows(
   rows: Record<string, unknown>[],

--- a/lib/hubble/shared-queries.mjs
+++ b/lib/hubble/shared-queries.mjs
@@ -1,0 +1,137 @@
+// Single source of truth for Hubble query SQL and their required parameters.
+// Imported by production code (via TypeScript) and the smoke-test script.
+
+export const TOP_ACCOUNTS_PER_TYPE = 70;
+export const TOP_CONTRACT_LIMIT = 200;
+export const TOP_SOROBAN_FUNCTIONS = 100;
+export const TOP_CONTRACTS_PER_FUNCTION = 70;
+
+export const ACCOUNT_QUERY_TYPES = [
+  "payment",
+  "path_payment_strict_receive",
+  "path_payment_strict_send",
+  "manage_buy_offer",
+  "manage_sell_offer",
+  "create_passive_sell_offer",
+  "change_trust",
+  "create_account",
+  "liquidity_pool_deposit",
+  "liquidity_pool_withdraw",
+];
+
+export const categoryQuery = `
+SELECT
+  type_string,
+  COUNT(*) AS op_count
+FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations\`
+WHERE closed_at BETWEEN @start AND @end
+GROUP BY type_string
+ORDER BY op_count DESC
+`;
+
+export const contractQuery = `
+SELECT
+  contract_id,
+  SUM(txn_count) AS op_count
+FROM \`crypto-stellar.crypto_stellar_dbt.hourly_soroban_fee_agg_contract\`
+WHERE hour_agg BETWEEN @start AND @end
+  AND contract_id IS NOT NULL
+  AND contract_id != ''
+GROUP BY contract_id
+ORDER BY op_count DESC
+LIMIT ${TOP_CONTRACT_LIMIT}
+`;
+
+export const accountQuery = `
+WITH ranked AS (
+  SELECT
+    op_source_account AS account_id,
+    type_string,
+    COUNT(*) AS op_count,
+    ROW_NUMBER() OVER (
+      PARTITION BY type_string
+      ORDER BY COUNT(*) DESC
+    ) AS rank
+  FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations\`
+  WHERE closed_at BETWEEN @start AND @end
+    AND type_string IN UNNEST(@types)
+  GROUP BY account_id, type_string
+)
+SELECT account_id, type_string, op_count
+FROM ranked
+WHERE rank <= ${TOP_ACCOUNTS_PER_TYPE}
+ORDER BY type_string, op_count DESC
+`;
+
+export const sorobanFunctionQuery = `
+WITH labeled AS (
+  SELECT
+    CASE
+      WHEN soroban_operation_type = 'invoke_contract'
+        AND parameters_decoded[SAFE_OFFSET(1)].type = 'Sym'
+      THEN parameters_decoded[SAFE_OFFSET(1)].value
+      ELSE soroban_operation_type
+    END AS function_name
+  FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations_soroban\`
+  WHERE closed_at BETWEEN @start AND @end
+)
+SELECT
+  function_name,
+  COUNT(*) AS op_count
+FROM labeled
+WHERE function_name IS NOT NULL AND function_name != ''
+GROUP BY function_name
+ORDER BY op_count DESC
+LIMIT ${TOP_SOROBAN_FUNCTIONS}
+`;
+
+export const sorobanFunctionContractQuery = `
+WITH aggregated AS (
+  SELECT
+    parameters_decoded[SAFE_OFFSET(1)].value AS function_name,
+    contract_id,
+    COUNT(*) AS op_count
+  FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations_soroban\`
+  WHERE closed_at BETWEEN @start AND @end
+    AND soroban_operation_type = 'invoke_contract'
+    AND parameters_decoded[SAFE_OFFSET(1)].type = 'Sym'
+    AND contract_id IS NOT NULL
+    AND contract_id != ''
+  GROUP BY function_name, contract_id
+),
+ranked AS (
+  SELECT
+    function_name,
+    contract_id,
+    op_count,
+    ROW_NUMBER() OVER (
+      PARTITION BY function_name
+      ORDER BY op_count DESC
+    ) AS rank
+  FROM aggregated
+)
+SELECT function_name, contract_id, op_count
+FROM ranked
+WHERE rank <= ${TOP_CONTRACTS_PER_FUNCTION}
+ORDER BY function_name, op_count DESC
+`;
+
+export const accountMetadataQuery = `
+SELECT
+  account_id,
+  home_domain
+FROM \`crypto-stellar.crypto_stellar_dbt.accounts_current\`
+WHERE account_id IN UNNEST(@ids)
+  AND home_domain IS NOT NULL
+  AND home_domain != ''
+`;
+
+/** @type {{ name: string, sql: string, requiredParams: string[] }[]} */
+export const queryRegistry = [
+  { name: "categoryQuery", sql: categoryQuery, requiredParams: ["start", "end"] },
+  { name: "contractQuery", sql: contractQuery, requiredParams: ["start", "end"] },
+  { name: "accountQuery", sql: accountQuery, requiredParams: ["start", "end", "types"] },
+  { name: "sorobanFunctionQuery", sql: sorobanFunctionQuery, requiredParams: ["start", "end"] },
+  { name: "sorobanFunctionContractQuery", sql: sorobanFunctionContractQuery, requiredParams: ["start", "end"] },
+  { name: "accountMetadataQuery", sql: accountMetadataQuery, requiredParams: ["ids"] },
+];

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "start": "next start",
     "lint": "eslint",
     "sync:directory": "node scripts/sync-stellar-directory.mjs",
-    "test:hubble": "node scripts/test-hubble-queries.mjs"
+    "test:hubble": "node scripts/test-hubble-queries.mjs",
+    "test:hubble:registry": "node scripts/test-query-registry.mjs"
   },
   "dependencies": {
     "@google-cloud/bigquery": "^8.3.1",

--- a/scripts/test-hubble-queries.mjs
+++ b/scripts/test-hubble-queries.mjs
@@ -1,131 +1,27 @@
 #!/usr/bin/env node
 
 import { BigQuery } from "@google-cloud/bigquery";
-
-const TOP_ACCOUNTS_PER_TYPE = 70;
-const TOP_CONTRACT_LIMIT = 200;
-const TOP_CONTRACTS_PER_FUNCTION = 70;
-const TOP_SOROBAN_FUNCTIONS = 100;
-const ACCOUNT_QUERY_TYPES = [
-  "payment",
-  "path_payment_strict_receive",
-  "path_payment_strict_send",
-  "manage_buy_offer",
-  "manage_sell_offer",
-  "create_passive_sell_offer",
-  "change_trust",
-  "create_account",
-  "liquidity_pool_deposit",
-  "liquidity_pool_withdraw",
-];
-
-const categoryQuery = `
-SELECT type_string, COUNT(*) AS op_count
-FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations\`
-WHERE closed_at BETWEEN @start AND @end
-GROUP BY type_string
-ORDER BY op_count DESC`;
-
-const contractQuery = `
-SELECT contract_id, SUM(txn_count) AS op_count
-FROM \`crypto-stellar.crypto_stellar_dbt.hourly_soroban_fee_agg_contract\`
-WHERE hour_agg BETWEEN @start AND @end
-  AND contract_id IS NOT NULL AND contract_id != ''
-GROUP BY contract_id
-ORDER BY op_count DESC
-LIMIT ${TOP_CONTRACT_LIMIT}`;
-
-const accountQuery = `
-WITH ranked AS (
-  SELECT
-    op_source_account AS account_id,
-    type_string,
-    COUNT(*) AS op_count,
-    ROW_NUMBER() OVER (PARTITION BY type_string ORDER BY COUNT(*) DESC) AS rank
-  FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations\`
-  WHERE closed_at BETWEEN @start AND @end
-    AND type_string IN UNNEST(@types)
-  GROUP BY account_id, type_string
-)
-SELECT account_id, type_string, op_count FROM ranked
-WHERE rank <= ${TOP_ACCOUNTS_PER_TYPE}
-ORDER BY type_string, op_count DESC`;
-
-const sorobanFunctionQuery = `
-WITH labeled AS (
-  SELECT
-    CASE
-      WHEN soroban_operation_type = 'invoke_contract'
-        AND parameters_decoded[SAFE_OFFSET(1)].type = 'Sym'
-      THEN parameters_decoded[SAFE_OFFSET(1)].value
-      ELSE soroban_operation_type
-    END AS function_name
-  FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations_soroban\`
-  WHERE closed_at BETWEEN @start AND @end
-)
-SELECT function_name, COUNT(*) AS op_count
-FROM labeled
-WHERE function_name IS NOT NULL AND function_name != ''
-GROUP BY function_name
-ORDER BY op_count DESC
-LIMIT ${TOP_SOROBAN_FUNCTIONS}`;
-
-const sorobanFunctionContractQuery = `
-WITH aggregated AS (
-  SELECT
-    parameters_decoded[SAFE_OFFSET(1)].value AS function_name,
-    contract_id,
-    COUNT(*) AS op_count
-  FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations_soroban\`
-  WHERE closed_at BETWEEN @start AND @end
-    AND soroban_operation_type = 'invoke_contract'
-    AND parameters_decoded[SAFE_OFFSET(1)].type = 'Sym'
-    AND contract_id IS NOT NULL AND contract_id != ''
-  GROUP BY function_name, contract_id
-),
-ranked AS (
-  SELECT
-    function_name,
-    contract_id,
-    op_count,
-    ROW_NUMBER() OVER (PARTITION BY function_name ORDER BY op_count DESC) AS rank
-  FROM aggregated
-)
-SELECT function_name, contract_id, op_count
-FROM ranked
-WHERE rank <= ${TOP_CONTRACTS_PER_FUNCTION}
-ORDER BY function_name, op_count DESC`;
+import { queryRegistry, ACCOUNT_QUERY_TYPES } from "../lib/hubble/shared-queries.mjs";
 
 const end = new Date().toISOString();
 const start = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-const baseParams = { start, end };
 
 const client = new BigQuery({
   projectId: process.env.GCP_PROJECT_ID ?? "stellar-501912",
 });
 
-const queries = [
-  { name: "categoryQuery", sql: categoryQuery, params: baseParams },
-  { name: "contractQuery", sql: contractQuery, params: baseParams },
-  {
-    name: "accountQuery",
-    sql: accountQuery,
-    params: { ...baseParams, types: ACCOUNT_QUERY_TYPES },
-  },
-  { name: "sorobanFunctionQuery", sql: sorobanFunctionQuery, params: baseParams },
-  {
-    name: "sorobanFunctionContractQuery",
-    sql: sorobanFunctionContractQuery,
-    params: baseParams,
-  },
-];
-
 let failed = false;
 
-for (const query of queries) {
-  process.stdout.write(`Testing ${query.name}... `);
+for (const entry of queryRegistry) {
+  process.stdout.write(`Testing ${entry.name}... `);
   try {
-    const [rows] = await client.query({ query: query.sql, params: query.params });
+    const params = {};
+    if (entry.requiredParams.includes("start")) params.start = start;
+    if (entry.requiredParams.includes("end")) params.end = end;
+    if (entry.requiredParams.includes("types")) params.types = ACCOUNT_QUERY_TYPES;
+    if (entry.requiredParams.includes("ids")) params.ids = [];
+
+    const [rows] = await client.query({ query: entry.sql, params });
     console.log(`ok (${rows.length} rows)`);
   } catch (error) {
     failed = true;

--- a/scripts/test-query-registry.mjs
+++ b/scripts/test-query-registry.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+import {
+  queryRegistry,
+  categoryQuery,
+  contractQuery,
+  accountQuery,
+  sorobanFunctionQuery,
+  sorobanFunctionContractQuery,
+  accountMetadataQuery,
+} from "../lib/hubble/shared-queries.mjs";
+
+const queryMap = {
+  categoryQuery,
+  contractQuery,
+  accountQuery,
+  sorobanFunctionQuery,
+  sorobanFunctionContractQuery,
+  accountMetadataQuery,
+};
+
+const registeredNames = new Set(queryRegistry.map((e) => e.name));
+let failed = false;
+
+for (const [name] of Object.entries(queryMap)) {
+  if (!registeredNames.has(name)) {
+    console.log(`FAIL: ${name} is exported but missing from queryRegistry`);
+    failed = true;
+  }
+}
+
+for (const entry of queryRegistry) {
+  if (!queryMap[entry.name]) {
+    console.log(`FAIL: queryRegistry has "${entry.name}" but no matching export`);
+    failed = true;
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}
+
+console.log(`ok — all ${queryRegistry.length} queries registered`);


### PR DESCRIPTION
Close: #37 

All done. Here's a summary of what was implemented:
lib/hubble/executor.ts — Shared query executor
- HubError — typed error with code field: "TIMEOUT", "CANCELLATION", "PROVIDER", or "VALIDATION"
- executeQuery<T>(query, params, timeoutMs?) — uses createQueryJob to get job identity; races a setTimeout against getQueryResults(); on timeout, fires job.cancel() (exactly once, fire-and-forget) and rejects with TIMEOUT; late completions are discarded via a settled flag
- setClientProvider(provider) — injectable client factory (mirrors setClock pattern from cache)
- DEFAULT_QUERY_TIMEOUT_MS = 30,000ms
lib/hubble/executor.test.ts — 8 tests with fake client
1. Completion before deadline — rows returned
2. Timeout with cancellable job — rejects with TIMEOUT, cancel called
3. Timeout without job identity — rejects with TIMEOUT, no cancel attempted
4. Cancellation failure — rejects with TIMEOUT (cancel throwing is non-fatal)
5. Late completion — rejects with TIMEOUT, late result discarded, promise state unchanged
6. VALIDATION — no client configured
7. PROVIDER — createQueryJob throws
8. Default timeout constant = 30,000
lib/hubble/activity.ts — Updated
- Private runQuery replaced with imported executeQuery
- getBigQueryClient import removed (no longer needed directly)