### PR TITLE
fix: reject unsupported periods and improve fallback behavior in activity route

### DIFF
--- a/app/api/activity/route.test.ts
+++ b/app/api/activity/route.test.ts
@@ -1,0 +1,65 @@
+import { GET } from "./route";
+import { getActivityData } from "@/lib/hubble/activity";
+import { NextRequest } from "next/server";
+
+// Mock the activity data fetcher
+jest.mock("@/lib/hubble/activity", () => ({
+  getActivityData: jest.fn(),
+}));
+
+describe("GET /api/activity", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 200 and defaults to 1d when period is missing", async () => {
+    const request = new Request("http://localhost/api/activity");
+    
+    (getActivityData as jest.Mock).mockResolvedValue({ data: "mock" });
+
+    const response = await GET(request);
+    
+    expect(response.status).toBe(200);
+    expect(getActivityData).toHaveBeenCalledTimes(1);
+    expect(getActivityData).toHaveBeenCalledWith("1d");
+  });
+
+  it("returns 200 for valid periods", async () => {
+    const periods = ["1d", "7d", "30d", "month"];
+    
+    for (const period of periods) {
+      const request = new Request(`http://localhost/api/activity?period=${period}`);
+      (getActivityData as jest.Mock).mockResolvedValue({ data: "mock" });
+      
+      const response = await GET(request);
+      
+      expect(response.status).toBe(200);
+      expect(getActivityData).toHaveBeenCalledWith(period);
+    }
+    expect(getActivityData).toHaveBeenCalledTimes(periods.length);
+  });
+
+  it("returns 400 for empty period", async () => {
+    const request = new Request("http://localhost/api/activity?period=");
+    
+    const response = await GET(request);
+    const data = await response.json();
+    
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Invalid period");
+    expect(data.supported).toEqual(["1d", "7d", "30d", "month"]);
+    expect(getActivityData).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for unsupported period", async () => {
+    const request = new Request("http://localhost/api/activity?period=1y");
+    
+    const response = await GET(request);
+    const data = await response.json();
+    
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Invalid period");
+    expect(data.supported).toEqual(["1d", "7d", "30d", "month"]);
+    expect(getActivityData).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/activity/route.ts
+++ b/app/api/activity/route.ts
@@ -1,13 +1,27 @@
 import { NextResponse } from "next/server";
 import { getActivityData } from "@/lib/hubble/activity";
-import { isValidPeriod } from "@/lib/periods";
+import { isValidPeriod, PERIOD_OPTIONS } from "@/lib/periods";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const periodParam = searchParams.get("period");
-  const period = isValidPeriod(periodParam) ? periodParam : "1d";
+
+  let period = "1d";
+  
+  if (periodParam !== null) {
+    if (!isValidPeriod(periodParam)) {
+      return NextResponse.json(
+        {
+          error: "Invalid period",
+          supported: PERIOD_OPTIONS.map((p) => p.value),
+        },
+        { status: 400 }
+      );
+    }
+    period = periodParam;
+  }
 
   try {
     const data = await getActivityData(period);


### PR DESCRIPTION
Closes #14 
### Description
**Problem:** 
An unsupported or empty `period` value in the `/api/activity` route currently falls back silently to `1d` and returns an HTTP 200 response. Client mistakes or typos can inadvertently produce plausible but incorrect research results due to this behavior.

**Solution:**
- **Strict Validation:** The route now explicitly rejects non-empty and unsupported `period` values, returning an HTTP 400 Bad Request status.
- **Improved Error Shape:** A stable public error shape is now used for validation failures, which includes a machine-readable `supported` array containing the valid `period` values.
- **Preserved Defaulting:** The `1d` default is now strictly preserved *only* when the `period` parameter is completely absent from the query.
- **Route Tests Added:** Added route-level tests (`app/api/activity/route.test.ts`) that systematically verify behavior for absent, valid, empty, and unsupported values. This ensures that invalid inputs return early without ever invoking the downstream BigQuery activity provider.

**Acceptance Criteria Met:**
- [x] A missing period returns the default 1-day response.
- [x] Each documented period remains accepted.
- [x] An empty or unsupported explicit period returns HTTP 400.
- [x] Invalid input never invokes the BigQuery activity provider.
- [x] The response contains no backend exception detail.
- [x] Route tests cover missing, valid, empty, and unsupported values.