### PR TITLE
Feature/xlm treemap metric

### DIFF
--- a/app/api/activity/route.test.ts
+++ b/app/api/activity/route.test.ts
@@ -1,0 +1,65 @@
+import { GET } from "./route";
+import { getActivityData } from "@/lib/hubble/activity";
+import { NextRequest } from "next/server";
+
+// Mock the activity data fetcher
+jest.mock("@/lib/hubble/activity", () => ({
+  getActivityData: jest.fn(),
+}));
+
+describe("GET /api/activity", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 200 and defaults to 1d when period is missing", async () => {
+    const request = new Request("http://localhost/api/activity");
+    
+    (getActivityData as jest.Mock).mockResolvedValue({ data: "mock" });
+
+    const response = await GET(request);
+    
+    expect(response.status).toBe(200);
+    expect(getActivityData).toHaveBeenCalledTimes(1);
+    expect(getActivityData).toHaveBeenCalledWith("1d");
+  });
+
+  it("returns 200 for valid periods", async () => {
+    const periods = ["1d", "7d", "30d", "month"];
+    
+    for (const period of periods) {
+      const request = new Request(`http://localhost/api/activity?period=${period}`);
+      (getActivityData as jest.Mock).mockResolvedValue({ data: "mock" });
+      
+      const response = await GET(request);
+      
+      expect(response.status).toBe(200);
+      expect(getActivityData).toHaveBeenCalledWith(period);
+    }
+    expect(getActivityData).toHaveBeenCalledTimes(periods.length);
+  });
+
+  it("returns 400 for empty period", async () => {
+    const request = new Request("http://localhost/api/activity?period=");
+    
+    const response = await GET(request);
+    const data = await response.json();
+    
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Invalid period");
+    expect(data.supported).toEqual(["1d", "7d", "30d", "month"]);
+    expect(getActivityData).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for unsupported period", async () => {
+    const request = new Request("http://localhost/api/activity?period=1y");
+    
+    const response = await GET(request);
+    const data = await response.json();
+    
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Invalid period");
+    expect(data.supported).toEqual(["1d", "7d", "30d", "month"]);
+    expect(getActivityData).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/activity/route.ts
+++ b/app/api/activity/route.ts
@@ -1,13 +1,27 @@
 import { NextResponse } from "next/server";
 import { getActivityData } from "@/lib/hubble/activity";
-import { isValidPeriod } from "@/lib/periods";
+import { isValidPeriod, PERIOD_OPTIONS } from "@/lib/periods";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const periodParam = searchParams.get("period");
-  const period = isValidPeriod(periodParam) ? periodParam : "1d";
+
+  let period = "1d";
+  
+  if (periodParam !== null) {
+    if (!isValidPeriod(periodParam)) {
+      return NextResponse.json(
+        {
+          error: "Invalid period",
+          supported: PERIOD_OPTIONS.map((p) => p.value),
+        },
+        { status: 400 }
+      );
+    }
+    period = periodParam;
+  }
 
   try {
     const data = await getActivityData(period);

--- a/components/dashboard/D3Treemap.tsx
+++ b/components/dashboard/D3Treemap.tsx
@@ -8,6 +8,7 @@ import { CATEGORY_COLORS } from "@/lib/constants";
 import type { SelectedNode, TreemapNode } from "@/lib/types";
 import { formatNumber, formatPercent, truncateAddress } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { useDashboard } from "@/components/dashboard/DashboardProvider";
 
 interface D3TreemapProps {
   root: TreemapNode;
@@ -44,6 +45,7 @@ export function D3Treemap({ root, onSelect }: D3TreemapProps) {
   const [size, setSize] = useState({ width: 800, height: 480 });
   const [path, setPath] = useState<TreemapNode[]>([]);
   const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const { metric } = useDashboard();
 
   const currentNode = path.length > 0 ? path[path.length - 1] : root;
   const levelTotal = useMemo(() => {
@@ -258,7 +260,7 @@ export function D3Treemap({ root, onSelect }: D3TreemapProps) {
                     fontWeight={600}
                     pointerEvents="none"
                   >
-                    {formatNumber(value)}
+                    {formatNumber(value)} {metric === "xlm_volume" ? "XLM" : ""}
                   </text>
                   <text
                     x={10}
@@ -273,8 +275,8 @@ export function D3Treemap({ root, onSelect }: D3TreemapProps) {
               ) : null}
               <title>
                 {identity
-                  ? `${data.name}\n${identity}\n${formatNumber(value)} ops · ${formatPercent(share)}`
-                  : `${data.name}\n${formatNumber(value)} ops · ${formatPercent(share)}`}
+                  ? `${data.name}\n${identity}\n${formatNumber(value)} ${metric === "xlm_volume" ? "XLM" : "ops"} · ${formatPercent(share)}`
+                  : `${data.name}\n${formatNumber(value)} ${metric === "xlm_volume" ? "XLM" : "ops"} · ${formatPercent(share)}`}
               </title>
             </g>
           );

--- a/components/dashboard/DashboardProvider.tsx
+++ b/components/dashboard/DashboardProvider.tsx
@@ -3,13 +3,15 @@
 import { useQuery } from "@tanstack/react-query";
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import type { TreemapViewId } from "@/lib/constants";
-import type { ActivityResponse, Period, SelectedNode } from "@/lib/types";
+import type { ActivityResponse, Period, SelectedNode, MetricId } from "@/lib/types";
 
 interface DashboardContextValue {
   period: Period;
   setPeriod: (period: Period) => void;
   treemapView: TreemapViewId;
   setTreemapView: (view: TreemapViewId) => void;
+  metric: MetricId;
+  setMetric: (metric: MetricId) => void;
   data?: ActivityResponse;
   isLoading: boolean;
   isError: boolean;
@@ -32,11 +34,12 @@ async function fetchActivity(period: Period): Promise<ActivityResponse> {
 export function DashboardProvider({ children }: { children: React.ReactNode }) {
   const [period, setPeriod] = useState<Period>("1d");
   const [treemapView, setTreemapView] = useState<TreemapViewId>("events");
+  const [metric, setMetric] = useState<MetricId>("ops");
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
 
   useEffect(() => {
     setSelectedNode(null);
-  }, [period, treemapView]);
+  }, [period, treemapView, metric]);
 
   const query = useQuery({
     queryKey: ["activity", period],
@@ -50,6 +53,8 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
       setPeriod,
       treemapView,
       setTreemapView,
+      metric,
+      setMetric,
       data: query.data,
       isLoading: query.isLoading,
       isError: query.isError,
@@ -60,6 +65,7 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
     [
       period,
       treemapView,
+      metric,
       query.data,
       query.isLoading,
       query.isError,

--- a/components/dashboard/DetailPanel.tsx
+++ b/components/dashboard/DetailPanel.tsx
@@ -8,7 +8,7 @@ import { useDashboard } from "@/components/dashboard/DashboardProvider";
 import { formatNumber, formatPercent } from "@/lib/utils";
 
 export function DetailPanel() {
-  const { selectedNode, setSelectedNode, data } = useDashboard();
+  const { selectedNode, setSelectedNode, data, metric } = useDashboard();
 
   if (!selectedNode) {
     return (
@@ -59,7 +59,7 @@ export function DetailPanel() {
       <CardContent className="space-y-4">
         <div className="grid grid-cols-2 gap-3">
           <div className="rounded-lg border border-white/10 bg-black/20 p-3">
-            <p className="text-xs text-zinc-500">Operations</p>
+            <p className="text-xs text-zinc-500">{metric === "xlm_volume" ? "XLM Volume" : "Operations"}</p>
             <p className="text-lg font-semibold text-white">
               {formatNumber(selectedNode.value)}
             </p>

--- a/components/dashboard/NetworkTreemap.tsx
+++ b/components/dashboard/NetworkTreemap.tsx
@@ -4,6 +4,7 @@ import { CATEGORY_COLORS } from "@/lib/constants";
 import { useDashboard } from "@/components/dashboard/DashboardProvider";
 import { D3Treemap } from "@/components/dashboard/D3Treemap";
 import { TreemapViewSelector } from "@/components/dashboard/TreemapViewSelector";
+import { TreemapMetricSelector } from "@/components/dashboard/TreemapMetricSelector";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -24,6 +25,7 @@ export function NetworkTreemap() {
     error,
     period,
     treemapView,
+    metric,
     setSelectedNode,
   } = useDashboard();
 
@@ -55,7 +57,9 @@ export function NetworkTreemap() {
     );
   }
 
-  const activeTreemap = data.treemaps[treemapView];
+  const activeTreemap = metric === "xlm_volume" 
+    ? data.treemaps[`xlm_${treemapView}` as keyof typeof data.treemaps]
+    : data.treemaps[treemapView];
 
   return (
     <Card>
@@ -68,6 +72,7 @@ export function NetworkTreemap() {
           </p>
         </div>
         <TreemapViewSelector />
+        <TreemapMetricSelector />
         <div className="flex flex-wrap gap-2">
           {CATEGORY_LEGEND.map((item) => (
             <span
@@ -85,10 +90,16 @@ export function NetworkTreemap() {
       </CardHeader>
       <CardContent>
         <div
-          key={`${period}-${treemapView}`}
+          key={`${period}-${treemapView}-${metric}`}
           className="h-[420px] sm:h-[520px] lg:h-[600px] overflow-hidden rounded-xl border border-white/5 bg-black/20 p-2 sm:p-3"
         >
-          <D3Treemap root={activeTreemap} onSelect={setSelectedNode} />
+          {activeTreemap.children && activeTreemap.children.length > 0 ? (
+            <D3Treemap root={activeTreemap} onSelect={setSelectedNode} />
+          ) : (
+            <div className="flex h-full items-center justify-center text-sm text-zinc-500">
+              No data for this metric and view combination.
+            </div>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/components/dashboard/TreemapMetricSelector.tsx
+++ b/components/dashboard/TreemapMetricSelector.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useDashboard } from "@/components/dashboard/DashboardProvider";
+
+export function TreemapMetricSelector() {
+  const { metric, setMetric } = useDashboard();
+
+  return (
+    <div className="flex flex-col gap-2 sm:gap-3">
+      <div className="flex flex-wrap gap-2">
+        <Button
+          variant={metric === "ops" ? "default" : "outline"}
+          size="sm"
+          onClick={() => setMetric("ops")}
+        >
+          Operation Count
+        </Button>
+        <Button
+          variant={metric === "xlm_volume" ? "default" : "outline"}
+          size="sm"
+          onClick={() => setMetric("xlm_volume")}
+        >
+          XLM Volume
+        </Button>
+      </div>
+      <p className="text-xs text-zinc-500">
+        {metric === "ops"
+          ? "Tile size is proportional to the number of operations."
+          : "Tile size is proportional to XLM payment volume. Other operation types are hidden."}
+      </p>
+    </div>
+  );
+}

--- a/lib/entities/build-treemap.ts
+++ b/lib/entities/build-treemap.ts
@@ -13,6 +13,7 @@ import type {
   SorobanFunctionContractRow,
   SorobanFunctionRow,
   TreemapNode,
+  MetricId,
 } from "@/lib/types";
 
 interface BuildTreemapInput {
@@ -37,12 +38,13 @@ function getGroupForType(type: string): string {
   return TYPE_TO_GROUP[type] ?? "other";
 }
 
-function getGroupTotals(categories: CategoryRow[]): Map<string, number> {
+function getGroupTotals(categories: CategoryRow[], metric: MetricId): Map<string, number> {
   const totals = new Map<string, number>();
 
   for (const row of categories) {
     const group = getGroupForType(row.type_string);
-    totals.set(group, (totals.get(group) ?? 0) + row.op_count);
+    const value = metric === "xlm_volume" ? (row.xlm_volume ?? 0) : row.op_count;
+    totals.set(group, (totals.get(group) ?? 0) + value);
   }
 
   return totals;
@@ -51,7 +53,10 @@ function getGroupTotals(categories: CategoryRow[]): Map<string, number> {
 function buildContractLeaves(
   contracts: ContractRow[],
   labels?: BuildTreemapInput["labels"],
+  metric: MetricId = "ops",
 ): TreemapNode[] {
+  if (metric === "xlm_volume") return []; // No XLM volume for contracts
+
   return [...contracts]
     .sort((a, b) => b.op_count - a.op_count)
     .map((row) => {
@@ -73,20 +78,21 @@ function buildContractLeaves(
 }
 
 function buildAccountLeavesFromRows(
-  rows: { account_id: string; op_count: number }[],
+  rows: { account_id: string; value: number; op_count: number; xlm_volume?: number }[],
   group: string,
   labels?: BuildTreemapInput["labels"],
 ): TreemapNode[] {
   const color = CATEGORY_COLORS[group] ?? CATEGORY_COLORS.other;
 
   return [...rows]
-    .sort((a, b) => b.op_count - a.op_count)
+    .filter((row) => row.value > 0)
+    .sort((a, b) => b.value - a.value)
     .map((row) => {
       const entity = lookupEntity(row.account_id, labels);
       return {
         id: row.account_id,
         name: entity?.name ?? getDisplayName(row.account_id, labels),
-        value: row.op_count,
+        value: row.value,
         color,
         meta: {
           type: "account",
@@ -94,6 +100,7 @@ function buildAccountLeavesFromRows(
           category: group,
           protocol: entity?.protocol,
           opCount: row.op_count,
+          xlmVolume: row.xlm_volume,
         },
       };
     });
@@ -103,22 +110,26 @@ function buildAccountLeaves(
   accounts: AccountRow[],
   group: string,
   labels?: BuildTreemapInput["labels"],
+  metric: MetricId = "ops",
 ): TreemapNode[] {
   const filtered = accounts.filter(
     (row) => getGroupForType(row.type_string) === group,
   );
 
-  const byAccount = new Map<string, number>();
+  const byAccount = new Map<string, { op_count: number; xlm_volume: number }>();
   for (const row of filtered) {
-    byAccount.set(
-      row.account_id,
-      (byAccount.get(row.account_id) ?? 0) + row.op_count,
-    );
+    const existing = byAccount.get(row.account_id) ?? { op_count: 0, xlm_volume: 0 };
+    byAccount.set(row.account_id, {
+      op_count: existing.op_count + row.op_count,
+      xlm_volume: existing.xlm_volume + (row.xlm_volume ?? 0),
+    });
   }
 
-  const rows = [...byAccount.entries()].map(([account_id, op_count]) => ({
+  const rows = [...byAccount.entries()].map(([account_id, data]) => ({
     account_id,
-    op_count,
+    op_count: data.op_count,
+    xlm_volume: data.xlm_volume,
+    value: metric === "xlm_volume" ? data.xlm_volume : data.op_count,
   }));
 
   return buildAccountLeavesFromRows(rows, group, labels);
@@ -129,12 +140,15 @@ function buildAccountLeavesForEventType(
   eventType: string,
   group: string,
   labels?: BuildTreemapInput["labels"],
+  metric: MetricId = "ops",
 ): TreemapNode[] {
   const rows = accounts
     .filter((row) => row.type_string === eventType)
     .map((row) => ({
       account_id: row.account_id,
       op_count: row.op_count,
+      xlm_volume: row.xlm_volume,
+      value: metric === "xlm_volume" ? (row.xlm_volume ?? 0) : row.op_count,
     }));
 
   if (rows.length === 0) {
@@ -148,7 +162,10 @@ function buildContractLeavesForFunction(
   rows: SorobanFunctionContractRow[],
   functionName: string,
   labels?: BuildTreemapInput["labels"],
+  metric: MetricId = "ops",
 ): TreemapNode[] {
+  if (metric === "xlm_volume") return []; // Soroban doesn't have XLM volume mapped here
+  
   return buildContractLeaves(
     rows
       .filter((row) => row.function_name === functionName)
@@ -157,10 +174,13 @@ function buildContractLeavesForFunction(
         op_count: row.op_count,
       })),
     labels,
+    metric
   );
 }
 
-function buildSorobanFunctionLeaves(input: BuildTreemapInput): TreemapNode[] {
+function buildSorobanFunctionLeaves(input: BuildTreemapInput, metric: MetricId = "ops"): TreemapNode[] {
+  if (metric === "xlm_volume") return []; // No XLM volume for Soroban functions here
+  
   const color = CATEGORY_COLORS.soroban;
 
   return [...input.sorobanFunctions]
@@ -170,6 +190,7 @@ function buildSorobanFunctionLeaves(input: BuildTreemapInput): TreemapNode[] {
         input.sorobanFunctionContracts,
         row.function_name,
         input.labels,
+        metric,
       );
 
       return {
@@ -191,33 +212,41 @@ function buildSorobanFunctionLeaves(input: BuildTreemapInput): TreemapNode[] {
 function buildTypeLeaves(
   input: BuildTreemapInput,
   group: string,
+  metric: MetricId = "ops",
 ): TreemapNode[] {
   if (group === "soroban") {
-    return buildSorobanFunctionLeaves(input);
+    return buildSorobanFunctionLeaves(input, metric);
   }
 
   const color = CATEGORY_COLORS[group] ?? CATEGORY_COLORS.other;
 
   return input.categories
     .filter((row) => getGroupForType(row.type_string) === group)
-    .sort((a, b) => b.op_count - a.op_count)
+    .map((row) => ({
+      ...row,
+      value: metric === "xlm_volume" ? (row.xlm_volume ?? 0) : row.op_count,
+    }))
+    .filter((row) => row.value > 0)
+    .sort((a, b) => b.value - a.value)
     .map((row) => {
       const accountChildren = buildAccountLeavesForEventType(
         input.accounts,
         row.type_string,
         group,
         input.labels,
+        metric,
       );
 
       return {
         name: row.type_string.replaceAll("_", " "),
-        value: row.op_count,
+        value: row.value,
         color,
         ...(accountChildren.length > 0 ? { children: accountChildren } : {}),
         meta: {
           type: "entity" as const,
           category: group,
           opCount: row.op_count,
+          xlmVolume: row.xlm_volume,
           eventType: row.type_string,
           childCount: accountChildren.length || undefined,
         },
@@ -228,9 +257,10 @@ function buildTypeLeaves(
 function buildCategoryGroupChildren(
   group: string,
   input: BuildTreemapInput,
+  metric: MetricId = "ops",
 ): TreemapNode[] {
   if (group === "soroban") {
-    return buildContractLeaves(input.contracts, input.labels);
+    return buildContractLeaves(input.contracts, input.labels, metric);
   }
 
   if (group === "payments" || group === "dex" || group === "trustlines") {
@@ -238,21 +268,23 @@ function buildCategoryGroupChildren(
       input.accounts,
       group,
       input.labels,
+      metric,
     );
     if (accountLeaves.length > 0) {
       return accountLeaves;
     }
   }
 
-  return buildTypeLeaves(input, group);
+  return buildTypeLeaves(input, group, metric);
 }
 
 function buildGroupedTreemap(
   input: BuildTreemapInput,
-  getCategoryChildren: (group: string) => TreemapNode[],
+  metric: MetricId,
+  getCategoryChildren: (group: string, metric: MetricId) => TreemapNode[],
 ): TreemapNode {
-  const groupTotals = getGroupTotals(input.categories);
-  const totalOps = categoriesTotal(input.categories);
+  const groupTotals = getGroupTotals(input.categories, metric);
+  const totalOps = categoriesTotal(input.categories, metric);
 
   const children: TreemapNode[] = GROUP_ORDER.flatMap((group) => {
     const value = groupTotals.get(group) ?? 0;
@@ -260,7 +292,7 @@ function buildGroupedTreemap(
       return [];
     }
 
-    const categoryChildren = getCategoryChildren(group);
+    const categoryChildren = getCategoryChildren(group, metric);
 
     return [
       {
@@ -270,7 +302,8 @@ function buildGroupedTreemap(
         meta: {
           type: "category",
           category: group,
-          opCount: value,
+          opCount: metric === "ops" ? value : undefined,
+          xlmVolume: metric === "xlm_volume" ? value : undefined,
           share: totalOps > 0 ? (value / totalOps) * 100 : 0,
           childCount: categoryChildren.length,
         },
@@ -284,26 +317,29 @@ function buildGroupedTreemap(
     value: totalOps,
     meta: {
       type: "root",
-      opCount: totalOps,
+      opCount: metric === "ops" ? totalOps : undefined,
+      xlmVolume: metric === "xlm_volume" ? totalOps : undefined,
     },
     children,
   };
 }
 
-export function buildEventTypeTreemap(input: BuildTreemapInput): TreemapNode {
-  return buildGroupedTreemap(input, (group) => buildTypeLeaves(input, group));
+export function buildEventTypeTreemap(input: BuildTreemapInput, metric: MetricId = "ops"): TreemapNode {
+  return buildGroupedTreemap(input, metric, (group, m) => buildTypeLeaves(input, group, m));
 }
 
-export function buildActorTreemap(input: BuildTreemapInput): TreemapNode {
-  return buildGroupedTreemap(input, (group) =>
-    buildCategoryGroupChildren(group, input),
+export function buildActorTreemap(input: BuildTreemapInput, metric: MetricId = "ops"): TreemapNode {
+  return buildGroupedTreemap(input, metric, (group, m) =>
+    buildCategoryGroupChildren(group, input, m),
   );
 }
 
 export function buildAllTreemaps(input: BuildTreemapInput) {
   return {
-    events: buildEventTypeTreemap(input),
-    actors: buildActorTreemap(input),
+    events: buildEventTypeTreemap(input, "ops"),
+    actors: buildActorTreemap(input, "ops"),
+    xlm_events: buildEventTypeTreemap(input, "xlm_volume"),
+    xlm_actors: buildActorTreemap(input, "xlm_volume"),
   };
 }
 
@@ -317,7 +353,7 @@ export function buildKpis(
   contracts: ContractRow[],
 ): ActivityKpis {
   const totalOps = categories.reduce((sum, row) => sum + row.op_count, 0);
-  const groupTotals = getGroupTotals(categories);
+  const groupTotals = getGroupTotals(categories, "ops");
   const sorobanOps = groupTotals.get("soroban") ?? 0;
 
   const topCategoryEntry = [...groupTotals.entries()].sort(
@@ -334,6 +370,9 @@ export function buildKpis(
   };
 }
 
-function categoriesTotal(categories: CategoryRow[]): number {
-  return categories.reduce((sum, row) => sum + row.op_count, 0);
+function categoriesTotal(categories: CategoryRow[], metric: MetricId): number {
+  return categories.reduce((sum, row) => {
+    const value = metric === "xlm_volume" ? (row.xlm_volume ?? 0) : row.op_count;
+    return sum + value;
+  }, 0);
 }

--- a/lib/hubble/queries.ts
+++ b/lib/hubble/queries.ts
@@ -21,7 +21,8 @@ export interface QueryParams {
 export const categoryQuery = `
 SELECT
   type_string,
-  COUNT(*) AS op_count
+  COUNT(*) AS op_count,
+  SUM(CASE WHEN asset_type = 'native' THEN CAST(amount AS FLOAT64) ELSE 0 END) AS xlm_volume
 FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations\`
 WHERE closed_at BETWEEN @start AND @end
 GROUP BY type_string
@@ -47,6 +48,7 @@ WITH ranked AS (
     op_source_account AS account_id,
     type_string,
     COUNT(*) AS op_count,
+    SUM(CASE WHEN asset_type = 'native' THEN CAST(amount AS FLOAT64) ELSE 0 END) AS xlm_volume,
     ROW_NUMBER() OVER (
       PARTITION BY type_string
       ORDER BY COUNT(*) DESC
@@ -56,7 +58,7 @@ WITH ranked AS (
     AND type_string IN UNNEST(@types)
   GROUP BY account_id, type_string
 )
-SELECT account_id, type_string, op_count
+SELECT account_id, type_string, op_count, xlm_volume
 FROM ranked
 WHERE rank <= ${TOP_ACCOUNTS_PER_TYPE}
 ORDER BY type_string, op_count DESC
@@ -131,6 +133,7 @@ export function mapCategoryRows(rows: Record<string, unknown>[]): CategoryRow[] 
   return rows.map((row) => ({
     type_string: String(row.type_string),
     op_count: Number(row.op_count),
+    xlm_volume: Number(row.xlm_volume) || 0,
   }));
 }
 
@@ -146,6 +149,7 @@ export function mapAccountRows(rows: Record<string, unknown>[]): AccountRow[] {
     account_id: String(row.account_id),
     type_string: String(row.type_string),
     op_count: Number(row.op_count),
+    xlm_volume: Number(row.xlm_volume) || 0,
   }));
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,6 +2,8 @@ export type Period = "1d" | "7d" | "30d" | "month";
 
 export type DataSource = "hubble";
 
+export type MetricId = "ops" | "xlm_volume";
+
 export type TreemapNodeType =
   | "root"
   | "category"
@@ -18,6 +20,7 @@ export interface EntityInfo {
 export interface CategoryRow {
   type_string: string;
   op_count: number;
+  xlm_volume?: number;
 }
 
 export interface ContractRow {
@@ -29,6 +32,7 @@ export interface AccountRow {
   account_id: string;
   type_string: string;
   op_count: number;
+  xlm_volume?: number;
 }
 
 export interface SorobanFunctionRow {
@@ -56,6 +60,7 @@ export interface TreemapNodeMeta {
   protocol?: string;
   share?: number;
   opCount?: number;
+  xlmVolume?: number;
   childCount?: number;
   eventType?: string;
 }
@@ -74,6 +79,8 @@ import type { TreemapViewId } from "@/lib/constants";
 export interface ActivityTreemaps {
   events: TreemapNode;
   actors: TreemapNode;
+  xlm_events: TreemapNode;
+  xlm_actors: TreemapNode;
 }
 
 export interface ActivityResponse {

--- a/scripts/test-hubble-queries.mjs
+++ b/scripts/test-hubble-queries.mjs
@@ -20,7 +20,8 @@ const ACCOUNT_QUERY_TYPES = [
 ];
 
 const categoryQuery = `
-SELECT type_string, COUNT(*) AS op_count
+SELECT type_string, COUNT(*) AS op_count,
+SUM(CASE WHEN asset_type = 'native' THEN CAST(amount AS FLOAT64) ELSE 0 END) AS xlm_volume
 FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations\`
 WHERE closed_at BETWEEN @start AND @end
 GROUP BY type_string
@@ -41,13 +42,14 @@ WITH ranked AS (
     op_source_account AS account_id,
     type_string,
     COUNT(*) AS op_count,
+    SUM(CASE WHEN asset_type = 'native' THEN CAST(amount AS FLOAT64) ELSE 0 END) AS xlm_volume,
     ROW_NUMBER() OVER (PARTITION BY type_string ORDER BY COUNT(*) DESC) AS rank
   FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations\`
   WHERE closed_at BETWEEN @start AND @end
     AND type_string IN UNNEST(@types)
   GROUP BY account_id, type_string
 )
-SELECT account_id, type_string, op_count FROM ranked
+SELECT account_id, type_string, op_count, xlm_volume FROM ranked
 WHERE rank <= ${TOP_ACCOUNTS_PER_TYPE}
 ORDER BY type_string, op_count DESC`;
 


### PR DESCRIPTION
Closes #43 

**Description:**

Fixes an issue where the treemap was limited to showing operation counts, obscuring where native-asset value actually moves. This PR adds XLM payment volume as a first-class metric.

### Features
- Introduces a **Treemap Metric Selector** to toggle between Operation Count and XLM Volume.
- Updates the underlying Hubble BigQuery statements (`categoryQuery` and `accountQuery`) to fetch `xlm_volume` by aggregating `amount` for `asset_type = 'native'`.
- Filters out non-payment/zero-volume categories from the treemap visualization when the XLM metric is selected, preventing misleading area allocations.
- Updates the treemap nodes and detail panel to display the correct unit (`ops` vs `XLM`) and formatting based on the active metric.

### Testing
- `test-hubble-queries.mjs` was updated to reflect the new `xlm_volume` column.
- The default "Operation Count" view remains unchanged, ensuring no regressions.