### PR TITLE
Add explicit remainder nodes to capped actor treemaps

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -7,6 +7,10 @@ export const CATEGORY_COLORS: Record<string, string> = {
   other: "#6B7280",
 };
 
+// Distinct, desaturated color for synthetic remainder tiles so they read
+// as "not a real actor" at a glance, independent of the group's color.
+export const REMAINDER_COLOR = "#3F3F46";
+
 export const GROUP_LABELS: Record<string, string> = {
   soroban: "Soroban Contracts",
   payments: "Payments",

--- a/lib/entities/build-treemap.test.ts
+++ b/lib/entities/build-treemap.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { buildActorTreemap } from "@/lib/entities/build-treemap";
+import type {
+  AccountRow,
+  CategoryRow,
+  ContractRow,
+} from "@/lib/types";
+
+function makeInput(overrides: {
+  categories?: CategoryRow[];
+  contracts?: ContractRow[];
+  accounts?: AccountRow[];
+}) {
+  return {
+    categories: overrides.categories ?? [],
+    contracts: overrides.contracts ?? [],
+    accounts: overrides.accounts ?? [],
+    sorobanFunctions: [],
+    sorobanFunctionContracts: [],
+  };
+}
+
+function findGroup(root: ReturnType<typeof buildActorTreemap>, category: string) {
+  const group = root.children?.find((node) => node.meta?.category === category);
+  if (!group) {
+    throw new Error(`Group "${category}" not found in treemap`);
+  }
+  return group;
+}
+
+function remainderNodes(children: ReturnType<typeof buildActorTreemap>["children"] = []) {
+  return children.filter((node) => node.meta?.type === "remainder");
+}
+
+describe("buildActorTreemap remainder nodes", () => {
+  it("adds exactly one remainder node when children are partially capped", () => {
+    const input = makeInput({
+      categories: [{ type_string: "payment", op_count: 100 }],
+      accounts: [
+        { account_id: "A", type_string: "payment", op_count: 40 },
+        { account_id: "B", type_string: "payment", op_count: 20 },
+      ],
+    });
+
+    const root = buildActorTreemap(input);
+    const payments = findGroup(root, "payments");
+    const remainders = remainderNodes(payments.children);
+
+    expect(remainders).toHaveLength(1);
+    expect(remainders[0].value).toBe(40);
+    expect(remainders[0].meta?.remainder).toBe(true);
+    expect(remainders[0].meta?.id).toBeUndefined();
+    expect(remainders[0].children).toBeUndefined();
+
+    const total = (payments.children ?? []).reduce(
+      (sum, node) => sum + (node.value ?? 0),
+      0,
+    );
+    expect(total).toBe(payments.value);
+  });
+
+  it("adds no remainder node when listed accounts already cover the total", () => {
+    const input = makeInput({
+      categories: [{ type_string: "payment", op_count: 100 }],
+      accounts: [{ account_id: "A", type_string: "payment", op_count: 100 }],
+    });
+
+    const root = buildActorTreemap(input);
+    const payments = findGroup(root, "payments");
+
+    expect(remainderNodes(payments.children)).toHaveLength(0);
+  });
+
+  it("adds no remainder node for groups that fall back to exact type leaves", () => {
+    // "set_options" isn't in ACCOUNT_QUERY_TYPES, so it always falls back
+    // to buildTypeLeaves, which is exact by construction.
+    const input = makeInput({
+      categories: [{ type_string: "set_options", op_count: 25 }],
+    });
+
+    const root = buildActorTreemap(input);
+    const account = findGroup(root, "account");
+
+    expect(remainderNodes(account.children)).toHaveLength(0);
+    expect(account.value).toBe(25);
+  });
+
+  it("throws instead of rendering when listed children exceed the parent total", () => {
+    const input = makeInput({
+      categories: [{ type_string: "payment", op_count: 50 }],
+      accounts: [
+        { account_id: "A", type_string: "payment", op_count: 40 },
+        { account_id: "B", type_string: "payment", op_count: 40 },
+      ],
+    });
+
+    expect(() => buildActorTreemap(input)).toThrow(/invariant violated/i);
+  });
+
+  it("reconciles the soroban group's contract remainder", () => {
+    const input = makeInput({
+      categories: [{ type_string: "invoke_host_function", op_count: 500 }],
+      contracts: [
+        { contract_id: "C1", op_count: 300 },
+        { contract_id: "C2", op_count: 150 },
+      ],
+    });
+
+    const root = buildActorTreemap(input);
+    const soroban = findGroup(root, "soroban");
+    const remainders = remainderNodes(soroban.children);
+
+    expect(remainders).toHaveLength(1);
+    expect(remainders[0].value).toBe(50);
+  });
+});

--- a/lib/entities/build-treemap.ts
+++ b/lib/entities/build-treemap.ts
@@ -1,8 +1,10 @@
 import {
   CATEGORY_COLORS,
   GROUP_LABELS,
+  REMAINDER_COLOR,
   TYPE_TO_GROUP,
 } from "@/lib/constants";
+
 import { getDisplayName, lookupEntity } from "@/lib/entities/registry";
 import type {
   AccountRow,
@@ -247,9 +249,65 @@ function buildCategoryGroupChildren(
   return buildTypeLeaves(input, group);
 }
 
+function getChildrenTotal(children: TreemapNode[]): number {
+  return children.reduce((sum, child) => sum + (child.value ?? 0), 0);
+}
+
+function buildRemainderNode(group: string, omittedValue: number): TreemapNode {
+  return {
+    name: "Other (unlisted actors)",
+    value: omittedValue,
+    color: REMAINDER_COLOR,
+    // Intentionally no `id` and no `children`: this keeps the node
+    // non-drillable and prevents it from ever being mistaken for a real
+    // account or contract tile.
+    meta: {
+      type: "remainder",
+      category: group,
+      opCount: omittedValue,
+      remainder: true,
+    },
+  };
+}
+
+/**
+ * Appends a synthetic remainder node when a group's listed children were
+ * capped upstream (e.g. top-N account/contract queries) and therefore sum
+ * to less than the group's true total.
+ *
+ * All inputs here are integer operation counts, so the precision rule is
+ * exact equality — no floating-point tolerance is applied.
+ *
+ * Throws if listed children exceed the parent total: that can only mean
+ * a double-counting bug or a metric mismatch upstream, and should fail
+ * loudly rather than render a nonsensical negative remainder.
+ */
+function withRemainder(
+  group: string,
+  parentValue: number,
+  children: TreemapNode[],
+): TreemapNode[] {
+  const listedTotal = getChildrenTotal(children);
+  const omitted = parentValue - listedTotal;
+
+  if (omitted < 0) {
+    throw new Error(
+      `Treemap invariant violated: listed children (${listedTotal}) exceed ` +
+        `parent total (${parentValue}) for actor group "${group}"`,
+    );
+  }
+
+  if (omitted === 0) {
+    return children;
+  }
+
+  return [...children, buildRemainderNode(group, omitted)];
+}
+
 function buildGroupedTreemap(
   input: BuildTreemapInput,
   getCategoryChildren: (group: string) => TreemapNode[],
+  options: { applyRemainder: boolean } = { applyRemainder: false },
 ): TreemapNode {
   const groupTotals = getGroupTotals(input.categories);
   const totalOps = categoriesTotal(input.categories);
@@ -260,7 +318,10 @@ function buildGroupedTreemap(
       return [];
     }
 
-    const categoryChildren = getCategoryChildren(group);
+    const rawChildren = getCategoryChildren(group);
+    const categoryChildren = options.applyRemainder
+      ? withRemainder(group, value, rawChildren)
+      : rawChildren;
 
     return [
       {
@@ -295,11 +356,12 @@ export function buildEventTypeTreemap(input: BuildTreemapInput): TreemapNode {
 }
 
 export function buildActorTreemap(input: BuildTreemapInput): TreemapNode {
-  return buildGroupedTreemap(input, (group) =>
-    buildCategoryGroupChildren(group, input),
+  return buildGroupedTreemap(
+    input,
+    (group) => buildCategoryGroupChildren(group, input),
+    { applyRemainder: true },
   );
 }
-
 export function buildAllTreemaps(input: BuildTreemapInput) {
   return {
     events: buildEventTypeTreemap(input),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,7 +7,8 @@ export type TreemapNodeType =
   | "category"
   | "entity"
   | "contract"
-  | "account";
+  | "account"
+  | "remainder";
 
 export interface EntityInfo {
   name: string;
@@ -58,6 +59,11 @@ export interface TreemapNodeMeta {
   opCount?: number;
   childCount?: number;
   eventType?: string;
+  /**
+   * True only for synthetic remainder nodes representing activity omitted
+   * by an upstream top-N cap. Never has an `id`, never drillable.
+   */
+  remainder?: boolean;
 }
 
 export interface TreemapNode {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "stellar-treemap",
+  "name": "lumenmap",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "stellar-treemap",
+      "name": "lumenmap",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@google-cloud/bigquery": "^8.3.1",
         "@tanstack/react-query": "^5.101.2",
@@ -76,7 +77,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -286,12 +286,31 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
       "dev": true,
-      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -1700,7 +1719,6 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1760,7 +1778,6 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -2364,7 +2381,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2771,7 +2787,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -3445,7 +3460,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3631,7 +3645,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6065,7 +6078,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6075,7 +6087,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6870,7 +6881,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7033,7 +7043,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7333,7 +7342,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "start": "next start",
     "lint": "eslint",
     "sync:directory": "node scripts/sync-stellar-directory.mjs",
-    "test:hubble": "node scripts/test-hubble-queries.mjs"
+    "test:hubble": "node scripts/test-hubble-queries.mjs",
+    "test": "vitest run"
   },
   "dependencies": {
     "@google-cloud/bigquery": "^8.3.1",


### PR DESCRIPTION
Closes #32

## Summary

Actor treemap groups (payments, DEX, trustlines, Soroban) receive
top-N-capped account/contract rows from BigQuery (see
`lib/hubble/queries.ts`: `TOP_ACCOUNTS_PER_TYPE`, `TOP_CONTRACT_LIMIT`),
while each group's parent total comes from the uncapped `categories`
query. Previously nothing accounted for the gap, so listed children
understated the group's real total and overstated each listed actor's
apparent share. This adds a synthetic, clearly-typed "Other (unlisted
actors)" tile whenever that gap is positive.

## Implementation

- `buildGroupedTreemap` now accepts an `applyRemainder` option. Only
  `buildActorTreemap` sets it; `buildEventTypeTreemap` is unchanged and
  behaves identically to before (its children come from `buildTypeLeaves`,
  which reads directly from the same uncapped `categories` rows used for
  the parent total, so it never has anything to reconcile).
- `withRemainder(group, parentValue, children)` computes
  `omitted = parentValue - sum(children.value)`:
  - `omitted > 0` → appends exactly one remainder node.
  - `omitted === 0` → returns children unchanged, no remainder node.
  - `omitted < 0` → throws, rather than rendering a nonsensical negative
    tile. This also guards the "soroban" group specifically, since its
    parent total (`categories`, from `enriched_history_operations`) and
    its children (`contracts`, from a separate
    `hourly_soroban_fee_agg_contract` aggregation) are two different
    BigQuery sources — if they ever drift inconsistently, this fails
    loudly instead of silently misrendering.
- Remainder nodes (`meta.type === "remainder"`, `meta.remainder === true`)
  have no `id` and no `children`, so they're structurally non-drillable
  and can't be confused with a real account/contract tile in
  `D3Treemap`'s existing rendering logic. They also get a dedicated
  `REMAINDER_COLOR` distinct from any category color.
- Precision rule: all inputs are integer operation counts, so equality
  is exact — no floating-point tolerance needed.

## Test infrastructure

This repo had no test runner configured. Added `vitest` as a dev
dependency and a `test` script, since the acceptance criteria requires
invariant/boundary test coverage.

## Test plan