### PR TITLE
fix: rework dashboard hierarchy around metric, period, visualization, and context

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,274 @@
+# Contributing to LumenMap
+
+Thank you for your interest in contributing. This guide covers everything you need to go from a fresh clone to an open pull request.
+
+---
+
+## Table of contents
+
+- [Architecture overview](#architecture-overview)
+- [Prerequisites](#prerequisites)
+- [Getting started](#getting-started)
+- [Fixture mode vs live mode](#fixture-mode-vs-live-mode)
+- [Project structure](#project-structure)
+- [Available commands](#available-commands)
+- [Making changes](#making-changes)
+- [Entity registry](#entity-registry)
+- [Branch and PR workflow](#branch-and-pr-workflow)
+- [Pull request expectations](#pull-request-expectations)
+
+---
+
+## Architecture overview
+
+```text
+Browser
+  → GET /api/activity?period=1d|7d|30d|month
+  → app/api/activity/route.ts
+      → no credentials → lib/hubble/fixture.ts   (fixture mode)
+      → credentials present → lib/hubble/activity.ts
+          → BigQuery (Hubble dataset)
+          → in-memory cache, 15 min TTL
+          → lib/entities/build-treemap.ts
+  → components/dashboard/DashboardProvider.tsx   (TanStack Query)
+  → components/dashboard/                        (React + D3)
+```
+
+The API has two modes. **Fixture mode** returns hardcoded sample data so the dashboard is fully functional without a GCP account. **Live mode** queries the [Hubble](https://developers.stellar.org/docs/data/analytics/hubble) dataset on BigQuery.
+
+---
+
+## Prerequisites
+
+- **Node.js 20+** (check with `node -v`)
+- **npm** (bundled with Node.js)
+- **GCP credentials** — only needed for live Hubble data, not for fixture mode
+
+---
+
+## Getting started
+
+```bash
+# 1. Fork the repository on GitHub, then clone your fork
+git clone https://github.com/<your-username>/lumenmap.git
+cd lumenmap
+
+# 2. Install dependencies
+npm install
+
+# 3. Copy the environment template
+cp .env.example .env.local
+
+# 4. Start the development server
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000). The dashboard loads immediately using fixture data — no GCP setup required.
+
+---
+
+## Fixture mode vs live mode
+
+### Fixture mode (default, no credentials needed)
+
+When neither `GOOGLE_APPLICATION_CREDENTIALS` nor `GCP_SERVICE_ACCOUNT_KEY` is set in `.env.local`, the API returns static sample data from [`lib/hubble/fixture.ts`](lib/hubble/fixture.ts). The response includes `"fixture": true` so you can tell at a glance which mode is active.
+
+Fixture mode is sufficient for:
+
+- Front-end layout and component work
+- Treemap interaction and drill-down
+- Entity registry additions
+- Anything that does not involve query logic or real network numbers
+
+### Live mode (requires GCP)
+
+To query real Hubble data you need a Google Cloud project with the BigQuery API enabled and a service account with the **BigQuery User** role.
+
+1. Create a service account and download the JSON key.
+2. Add it to `.env.local`:
+
+   ```env
+   # Option A — local file path
+   GOOGLE_APPLICATION_CREDENTIALS=./gcp-sa.json
+
+   # Option B — base64-encoded JSON (useful for CI and deployment)
+   # GCP_SERVICE_ACCOUNT_KEY=<base64-string>
+   ```
+
+3. Restart the dev server. The API will now query Hubble and the response will not contain `"fixture": true`.
+
+Hubble setup guide: [Connecting to BigQuery](https://developers.stellar.org/docs/data/analytics/hubble/developer-guide/connecting-to-bigquery).
+
+> **Do not commit `gcp-sa.json` or `.env.local`.** Both are in `.gitignore`. Each contributor uses their own credentials.
+
+---
+
+## Project structure
+
+```text
+app/
+  page.tsx                     Entry point
+  layout.tsx
+  api/activity/route.ts        GET /api/activity — fixture or live
+  globals.css
+
+components/dashboard/
+  DashboardPage.tsx            Root dashboard component
+  DashboardProvider.tsx        TanStack Query + shared state
+  D3Treemap.tsx                Squarified D3 treemap
+  NetworkTreemap.tsx           Treemap wrapper with drill-down
+  KpiCards.tsx                 KPI strip
+  DetailPanel.tsx              Right-side detail panel
+  PeriodSelector.tsx           1d / 7d / 30d / month toggle
+  TreemapViewSelector.tsx      Operation Types / Accounts view toggle
+components/ui/                 Generic UI primitives (button, card, …)
+components/providers.tsx       React Query provider
+
+lib/
+  types.ts                     Shared TypeScript types
+  constants.ts                 Category colours, group labels, query limits
+  periods.ts                   Period resolution (start/end date logic)
+  utils.ts                     Shared helpers
+  hubble/
+    activity.ts                Orchestrates BigQuery queries and caching
+    client.ts                  BigQuery client + hasBigQueryCredentials()
+    cache.ts                   In-memory cache with TTL
+    queries.ts                 SQL query strings and row mappers
+    fixture.ts                 Static sample data for fixture mode
+  entities/
+    registry.ts                Loads entities.json + directory.json
+    resolve-labels.ts          Fetches home_domain labels from Hubble
+    build-treemap.ts           Converts raw rows into treemap nodes
+
+data/
+  entities.json                Hand-curated wallet and contract labels
+  directory.json               Synced from Stellar Expert directory
+
+scripts/
+  test-hubble-queries.mjs      Smoke-tests all BigQuery queries
+  sync-stellar-directory.mjs   Pulls latest labels from Stellar Expert
+```
+
+---
+
+## Available commands
+
+| Command | What it does |
+| --- | --- |
+| `npm run dev` | Development server with hot reload |
+| `npm run build` | Production build |
+| `npm run start` | Production server (run `build` first) |
+| `npm run lint` | ESLint — run before every PR |
+| `npm run test:hubble` | Smoke-tests all BigQuery queries (requires GCP) |
+| `npm run sync:directory` | Pulls entity labels from Stellar Expert |
+
+---
+
+## Making changes
+
+### Front-end only changes
+
+No GCP credentials needed. Start the dev server and work directly:
+
+```bash
+npm run dev
+# edit components/, lib/, or data/ freely
+npm run lint       # check before committing
+```
+
+### Query changes (requires GCP)
+
+1. Edit queries in `lib/hubble/queries.ts` or `lib/hubble/activity.ts`.
+2. Test against live data:
+
+   ```bash
+   npm run test:hubble
+   ```
+
+3. If you change the shape of the response, update `lib/hubble/fixture.ts` to match so fixture mode stays representative.
+
+4. Bump the cache key prefix in `lib/hubble/activity.ts` (e.g. `activity:v10:` → `activity:v11:`) to avoid serving stale cached responses to existing instances.
+
+### Updating entity labels
+
+To add or correct a wallet or contract label, edit [`data/entities.json`](data/entities.json) directly:
+
+```json
+{
+  "G...": { "name": "My Protocol", "category": "defi", "protocol": "My Protocol" }
+}
+```
+
+To pull the latest names from the Stellar Expert directory:
+
+```bash
+npm run sync:directory
+```
+
+This overwrites `data/directory.json`. Commit both the script run and any manual changes to `entities.json` together.
+
+---
+
+## Entity registry
+
+LumenMap labels addresses using two sources, merged at startup:
+
+| File | Source | Edit how |
+| --- | --- | --- |
+| `data/entities.json` | Hand-curated | Edit directly |
+| `data/directory.json` | Stellar Expert | `npm run sync:directory` |
+
+Entries in `entities.json` override `directory.json` for the same address. Use `entities.json` for corrections and additions that Stellar Expert does not yet carry.
+
+Valid categories: `defi`, `exchange`, `wallet`, `anchor`, `issuer`, `other`.
+
+---
+
+## Branch and PR workflow
+
+1. **Check or open an issue** before starting non-trivial work. Comment on the issue to signal you are working on it.
+
+2. **Create a branch** from `main`:
+
+   ```bash
+   git checkout -b feat/short-description
+   # or
+   git checkout -b fix/short-description
+   ```
+
+   Use `feat/`, `fix/`, `chore/`, or `docs/` prefixes.
+
+3. **Make focused commits.** One logical change per commit is easier to review than a single large commit.
+
+4. **Lint before pushing:**
+
+   ```bash
+   npm run lint
+   ```
+
+5. **Push your branch and open a PR:**
+
+   ```bash
+   git push -u origin feat/short-description
+   ```
+
+   Then open a pull request on GitHub targeting `main`.
+
+---
+
+## Pull request expectations
+
+- **Title:** Short and specific, under 70 characters. Bad: `Updates`. Good: `Add fixture mode for credential-free development`.
+- **Description:** Explain what changed and why. Mention the issue it closes with `Closes #<number>`.
+- **Scope:** Keep PRs small and focused. A PR that does one thing is faster to review and easier to revert.
+- **Lint:** `npm run lint` must pass with no errors.
+- **Query changes:** Run `npm run test:hubble` and include the output in the PR description. If you do not have GCP access, note that clearly and ask a maintainer to verify.
+- **Fixture data:** If you add or rename response fields, update `lib/hubble/fixture.ts` to reflect the new shape.
+- **Entity additions:** Small additions to `data/entities.json` can be bundled into a single PR. Large batch updates should be their own PR.
+- **No credentials in commits:** Double-check that `gcp-sa.json` and `.env.local` are not staged.
+
+---
+
+## Questions
+
+Open an issue or start a discussion on [github.com/lumenmap/lumenmap](https://github.com/lumenmap/lumenmap).

--- a/README.md
+++ b/README.md
@@ -140,8 +140,7 @@ Dataset: `crypto-stellar.crypto_stellar_dbt`
 ### Prerequisites
 
 - Node.js 20+
-- Google Cloud project with BigQuery API enabled
-- Service account with BigQuery User role
+- Google Cloud project with BigQuery API enabled (only needed for live data — see [CONTRIBUTING.md](CONTRIBUTING.md))
 
 ### Install and run
 
@@ -151,7 +150,7 @@ cp .env.example .env.local
 npm run dev
 ```
 
-Set GCP credentials in `.env.local`, then open [http://localhost:3000](http://localhost:3000).
+Open [http://localhost:3000](http://localhost:3000). The dashboard runs in **fixture mode** with sample data and needs no GCP credentials. To query live Hubble data, set GCP credentials in `.env.local` and restart.
 
 ### Environment variables
 
@@ -272,12 +271,15 @@ scripts/
 
 ## Contributing
 
-Contributions are welcome at [github.com/lumenmap/lumenmap](https://github.com/lumenmap/lumenmap).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide: setup, fixture mode, project structure, commands, branch workflow, and PR expectations.
 
-1. Fork the repository and create a branch.
-2. Make your changes. Run `npm run lint` before opening a pull request.
-3. If you change Hubble queries, run `npm run test:hubble` with valid GCP credentials.
-4. Open a pull request with a short description of what changed and why.
+Quick start:
+
+```bash
+git clone https://github.com/<your-username>/lumenmap.git
+cd lumenmap && npm install && cp .env.example .env.local
+npm run dev   # dashboard opens in fixture mode — no GCP required
+```
 
 To add wallet or dApp labels, edit [`data/entities.json`](data/entities.json) or run `npm run sync:directory`.
 

--- a/app/api/activity/route.ts
+++ b/app/api/activity/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 import { getActivityData } from "@/lib/hubble/activity";
+import { hasBigQueryCredentials } from "@/lib/hubble/client";
+import { fixtureResponse } from "@/lib/hubble/fixture";
 import { isValidPeriod } from "@/lib/periods";
 
 export const dynamic = "force-dynamic";
@@ -8,6 +10,12 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const periodParam = searchParams.get("period");
   const period = isValidPeriod(periodParam) ? periodParam : "1d";
+
+  // Fixture mode: no credentials configured, return static sample data so the
+  // dashboard is usable without a GCP project.
+  if (!hasBigQueryCredentials()) {
+    return NextResponse.json({ ...fixtureResponse, period, fixture: true });
+  }
 
   try {
     const data = await getActivityData(period);

--- a/app/globals.css
+++ b/app/globals.css
@@ -40,3 +40,39 @@ input,
 textarea {
   font: inherit;
 }
+
+/* ─── Touch target utilities ─────────────────────────────────────────────────
+ *
+ * All interactive controls must present a minimum 44×44 CSS-pixel hit area
+ * as recommended by WCAG 2.5.5 (Target Size, AAA) and Apple / Google HIG.
+ *
+ * The .touch-target class can be applied to any element whose visual size
+ * is smaller than 44px. It expands the clickable area via a transparent
+ * pseudo-element overlay without altering layout or visual density.
+ *
+ * Usage:  <button class="touch-target …">…</button>
+ *
+ * Note: the Button component already enforces h-11 (44px) for all sizes so
+ * .touch-target is a supplementary escape hatch for custom interactive elements
+ * (e.g., bare <a> tags, SVG hit areas, third-party components).
+ * ─────────────────────────────────────────────────────────────────────────── */
+.touch-target {
+  position: relative;
+}
+
+.touch-target::after {
+  content: "";
+  position: absolute;
+  /* Expand hit area to at least 44×44px centered on the element */
+  inset: 50% auto auto 50%;
+  transform: translate(-50%, -50%);
+  min-width: 44px;
+  min-height: 44px;
+  width: 100%;
+  height: 100%;
+}
+
+/* Prevent accidental multi-touch zoom on interactive dashboard controls */
+.touch-manipulation {
+  touch-action: manipulation;
+}

--- a/components/dashboard/ControlBar.tsx
+++ b/components/dashboard/ControlBar.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { PERIOD_OPTIONS } from "@/lib/periods";
+import { TREEMAP_VIEWS } from "@/lib/constants";
+import { Button } from "@/components/ui/button";
+import { useDashboard } from "@/components/dashboard/DashboardProvider";
+
+/**
+ * ControlBar
+ *
+ * Groups the two primary page controls together so they are immediately
+ * discoverable beneath the site header:
+ *   - Metric view  (Operation Types / Accounts & Contracts)
+ *   - Time period  (Today / 7 Days / 30 Days / This Month)
+ *
+ * The section is labelled as an h2 landmark so keyboard and screen-reader
+ * users encounter controls before the treemap in reading order.
+ */
+export function ControlBar() {
+  const { period, setPeriod, treemapView, setTreemapView } = useDashboard();
+
+  const activeView = TREEMAP_VIEWS.find((v) => v.id === treemapView);
+
+  return (
+    <section aria-labelledby="controls-heading">
+      <h2 id="controls-heading" className="sr-only">
+        Dashboard controls
+      </h2>
+
+      <div className="flex flex-col gap-4 rounded-xl border border-white/10 bg-white/5 px-4 py-3 sm:flex-row sm:items-start sm:gap-6">
+        {/* ── Metric view ─────────────────────────────────────── */}
+        <div className="flex flex-col gap-2">
+          <p className="text-xs font-medium uppercase tracking-widest text-zinc-500">
+            View
+          </p>
+          <div
+            role="group"
+            aria-label="Metric view"
+            className="flex flex-wrap gap-2"
+          >
+            {TREEMAP_VIEWS.map((view) => (
+              <Button
+                key={view.id}
+                variant={treemapView === view.id ? "default" : "outline"}
+                size="sm"
+                onClick={() => setTreemapView(view.id)}
+                aria-pressed={treemapView === view.id}
+              >
+                {view.label}
+              </Button>
+            ))}
+          </div>
+          {activeView ? (
+            <p className="text-xs text-zinc-500">{activeView.description}</p>
+          ) : null}
+        </div>
+
+        {/* Vertical divider – desktop only */}
+        <div
+          aria-hidden="true"
+          className="hidden w-px self-stretch bg-white/10 sm:block"
+        />
+
+        {/* ── Time period ─────────────────────────────────────── */}
+        <div className="flex flex-col gap-2">
+          <p className="text-xs font-medium uppercase tracking-widest text-zinc-500">
+            Period
+          </p>
+          <div
+            role="group"
+            aria-label="Time period"
+            className="flex flex-wrap gap-2"
+          >
+            {PERIOD_OPTIONS.map((option) => (
+              <Button
+                key={option.value}
+                variant={period === option.value ? "default" : "outline"}
+                size="sm"
+                onClick={() => setPeriod(option.value)}
+                aria-pressed={period === option.value}
+              >
+                {option.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/dashboard/ControlBar.tsx
+++ b/components/dashboard/ControlBar.tsx
@@ -13,8 +13,8 @@ import { useDashboard } from "@/components/dashboard/DashboardProvider";
  *   - Metric view  (Operation Types / Accounts & Contracts)
  *   - Time period  (Today / 7 Days / 30 Days / This Month)
  *
- * The section is labelled as an h2 landmark so keyboard and screen-reader
- * users encounter controls before the treemap in reading order.
+ * Uses a visible h2 heading so the control hierarchy is clear in the
+ * document outline and for all users.
  */
 export function ControlBar() {
   const { period, setPeriod, treemapView, setTreemapView } = useDashboard();
@@ -23,8 +23,11 @@ export function ControlBar() {
 
   return (
     <section aria-labelledby="controls-heading">
-      <h2 id="controls-heading" className="sr-only">
-        Dashboard controls
+      <h2
+        id="controls-heading"
+        className="mb-3 text-lg font-semibold text-white"
+      >
+        Controls
       </h2>
 
       <div className="flex flex-col gap-4 rounded-xl border border-white/10 bg-white/5 px-4 py-3 sm:flex-row sm:items-start sm:gap-6">

--- a/components/dashboard/D3Treemap.tsx
+++ b/components/dashboard/D3Treemap.tsx
@@ -162,21 +162,33 @@ export function D3Treemap({ root, onSelect }: D3TreemapProps) {
 
   return (
     <div ref={containerRef} className="flex h-full min-h-0 w-full flex-col">
-      <div className="mb-3 flex shrink-0 flex-wrap items-center gap-1 text-xs text-zinc-400">
+      {/* Breadcrumb nav — min-h-[44px] ensures the row meets touch target height.
+          Each Button uses size="sm" which is already h-11 (44px). The shrink-0
+          prevents the row from compressing on small containers. */}
+      <nav
+        aria-label="Treemap navigation"
+        className="mb-2 flex min-h-[44px] shrink-0 flex-wrap items-center gap-0.5 text-xs text-zinc-400"
+      >
         {breadcrumbs.map((crumb, index) => (
-          <div key={`${crumb.name}-${index}`} className="flex items-center gap-1">
-            {index > 0 ? <ChevronRight className="h-3 w-3 text-zinc-600" /> : null}
+          <div key={`${crumb.name}-${index}`} className="flex items-center">
+            {index > 0 ? (
+              <ChevronRight
+                className="h-3 w-3 shrink-0 text-zinc-600"
+                aria-hidden="true"
+              />
+            ) : null}
             <Button
               variant="ghost"
               size="sm"
-              className="h-7 px-2 text-xs text-zinc-300 hover:text-white"
+              className="px-2 text-xs text-zinc-300 hover:text-white"
               onClick={() => navigateTo(index - 1)}
+              aria-current={index === breadcrumbs.length - 1 ? "page" : undefined}
             >
               {crumb.name}
             </Button>
           </div>
         ))}
-      </div>
+      </nav>
 
       <div ref={chartRef} className="min-h-0 flex-1">
         <svg
@@ -204,6 +216,14 @@ export function D3Treemap({ root, onSelect }: D3TreemapProps) {
 
           const canDrill = Boolean(original?.children?.length);
 
+          // Tiles smaller than 44px in either dimension cannot be accurately tapped
+          // on touch screens. They still have a <title> for pointer tooltip.
+          // We also add role, tabIndex, and aria-label so keyboard and assistive
+          // technology users can reach and activate them regardless of size.
+          const ariaLabel = identity
+            ? `${data.name}, ${identity}, ${formatNumber(value)} ops, ${formatPercent(share)}`
+            : `${data.name}, ${formatNumber(value)} ops, ${formatPercent(share)}`;
+
           return (
             <g
               key={nodeId}
@@ -211,7 +231,17 @@ export function D3Treemap({ root, onSelect }: D3TreemapProps) {
               onMouseEnter={() => setHoveredId(nodeId)}
               onMouseLeave={() => setHoveredId(null)}
               onClick={() => handleNodeClick(node)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  handleNodeClick(node);
+                }
+              }}
+              tabIndex={0}
+              role="button"
+              aria-label={ariaLabel}
               style={{ cursor: canDrill ? "zoom-in" : "pointer" }}
+              className="focus-visible:outline-none focus-visible:[&>rect]:stroke-white focus-visible:[&>rect]:stroke-2"
             >
               <rect
                 width={width}
@@ -271,6 +301,8 @@ export function D3Treemap({ root, onSelect }: D3TreemapProps) {
                   </text>
                 </>
               ) : null}
+              {/* <title> provides tooltip on pointer hover and is read by screen readers
+                  as a fallback description for tiles that are too small to display text */}
               <title>
                 {identity
                   ? `${data.name}\n${identity}\n${formatNumber(value)} ops · ${formatPercent(share)}`

--- a/components/dashboard/DashboardPage.tsx
+++ b/components/dashboard/DashboardPage.tsx
@@ -6,10 +6,10 @@ import {
   DashboardProvider,
   useDashboard,
 } from "@/components/dashboard/DashboardProvider";
+import { ControlBar } from "@/components/dashboard/ControlBar";
 import { DetailPanel } from "@/components/dashboard/DetailPanel";
 import { KpiCards } from "@/components/dashboard/KpiCards";
 import { NetworkTreemap } from "@/components/dashboard/NetworkTreemap";
-import { PeriodSelector } from "@/components/dashboard/PeriodSelector";
 
 function DataSourceNotice() {
   const { data } = useDashboard();
@@ -30,38 +30,64 @@ function DataSourceNotice() {
 function DashboardContent() {
   return (
     <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
-      <header className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-        <div className="space-y-3">
-          <div className="flex flex-wrap items-center gap-3">
-            <Image
-              src="/logo.png"
-              alt="LumenMap"
-              width={44}
-              height={44}
-              className="shrink-0"
-              priority
-            />
-            <div>
-              <h1 className="text-2xl font-semibold tracking-tight text-white sm:text-3xl">
-                LumenMap
-              </h1>
-              <p className="text-sm text-zinc-400">
-                Stellar network activity across mainnet.
-              </p>
-            </div>
-            <Badge>Mainnet</Badge>
+      {/* ── 1. Site header (h1) ─────────────────────────────────────────── */}
+      <header>
+        <div className="flex flex-wrap items-center gap-3">
+          <Image
+            src="/logo.png"
+            alt="LumenMap"
+            width={44}
+            height={44}
+            className="shrink-0"
+            priority
+          />
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight text-white sm:text-3xl">
+              LumenMap
+            </h1>
+            <p className="text-sm text-zinc-400">
+              Stellar network activity across mainnet.
+            </p>
           </div>
+          <Badge>Mainnet</Badge>
+        </div>
+        <div className="mt-3">
           <DataSourceNotice />
         </div>
-        <PeriodSelector />
       </header>
 
-      <KpiCards />
+      {/* ── 2. Primary controls (metric view + period) ──────────────────── */}
+      <ControlBar />
 
-      <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
-        <NetworkTreemap />
-        <DetailPanel />
-      </div>
+      {/* ── 3. Primary visualization + detail sidebar (desktop) ─────────── */}
+      {/*
+        Layout:
+          • Mobile:  treemap → detail panel → KPI cards (stacked)
+          • Desktop: [treemap  |  detail sidebar]  then KPI cards full-width below
+        The detail panel appears directly below the treemap on mobile so the
+        user can act on a selection without scrolling past KPIs first.
+      */}
+      <section aria-labelledby="treemap-heading">
+        <h2 id="treemap-heading" className="sr-only">
+          Network activity treemap
+        </h2>
+
+        <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
+          {/* Treemap always renders first in DOM order (keyboard / screen reader) */}
+          <NetworkTreemap />
+
+          {/* Detail panel – sidebar on desktop, stacked below treemap on mobile */}
+          <DetailPanel />
+        </div>
+      </section>
+
+      {/* ── 4. Secondary context: KPI summary cards ─────────────────────── */}
+      <section aria-labelledby="kpis-heading">
+        <h2 id="kpis-heading" className="sr-only">
+          Key metrics
+        </h2>
+        <KpiCards />
+      </section>
     </div>
   );
 }

--- a/components/dashboard/DashboardPage.tsx
+++ b/components/dashboard/DashboardPage.tsx
@@ -29,7 +29,7 @@ function DataSourceNotice() {
 
 function DashboardContent() {
   return (
-    <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
+    <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 px-4 py-6 sm:px-6 lg:px-8">
       {/* ── 1. Site header (h1) ─────────────────────────────────────────── */}
       <header>
         <div className="flex flex-wrap items-center gap-3">
@@ -51,42 +51,56 @@ function DashboardContent() {
           </div>
           <Badge>Mainnet</Badge>
         </div>
-        <div className="mt-3">
-          <DataSourceNotice />
-        </div>
       </header>
 
-      {/* ── 2. Primary controls (metric view + period) ──────────────────── */}
+      {/* ── 2. Primary controls (metric + period) ───────────────────────── */}
       <ControlBar />
 
-      {/* ── 3. Primary visualization + detail sidebar (desktop) ─────────── */}
+      {/* ── 3. Primary visualization ────────────────────────────────────── */}
       {/*
-        Layout:
-          • Mobile:  treemap → detail panel → KPI cards (stacked)
-          • Desktop: [treemap  |  detail sidebar]  then KPI cards full-width below
-        The detail panel appears directly below the treemap on mobile so the
-        user can act on a selection without scrolling past KPIs first.
+        Full-width treemap dominates the initial viewport.
+        Detail panel is placed in the secondary context section below
+        so it does not compete with the primary visualization.
       */}
       <section aria-labelledby="treemap-heading">
-        <h2 id="treemap-heading" className="sr-only">
-          Network activity treemap
+        <h2
+          id="treemap-heading"
+          className="mb-4 text-lg font-semibold text-white"
+        >
+          Network Activity
         </h2>
-
-        <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
-          {/* Treemap always renders first in DOM order (keyboard / screen reader) */}
-          <NetworkTreemap />
-
-          {/* Detail panel – sidebar on desktop, stacked below treemap on mobile */}
-          <DetailPanel />
-        </div>
+        <NetworkTreemap />
       </section>
 
-      {/* ── 4. Secondary context: KPI summary cards ─────────────────────── */}
-      <section aria-labelledby="kpis-heading">
-        <h2 id="kpis-heading" className="sr-only">
-          Key metrics
+      {/* ── 4. Secondary context: details + KPIs + methodology ──────────── */}
+      {/*
+        Layout:
+          • Mobile: detail panel first (user sees selection immediately),
+            then KPIs, then data-source notice (stacked).
+          • Desktop: KPIs + notice on the left, detail panel on the right.
+        The detail panel appears before KPIs on mobile so the user can act
+        on a selection without scrolling past KPI cards first.
+      */}
+      <section aria-labelledby="details-heading">
+        <h2
+          id="details-heading"
+          className="mb-4 text-lg font-semibold text-white"
+        >
+          Details & Metrics
         </h2>
-        <KpiCards />
+
+        <div className="flex flex-col gap-6 lg:grid lg:grid-cols-[1fr_320px]">
+          {/* Detail panel – first on mobile (order-1), right column on desktop (order-2) */}
+          <div className="order-1 lg:order-2">
+            <DetailPanel />
+          </div>
+
+          {/* KPIs + methodology – second on mobile (order-2), left column on desktop (order-1) */}
+          <div className="order-2 lg:order-1 flex flex-col gap-6">
+            <KpiCards />
+            <DataSourceNotice />
+          </div>
+        </div>
       </section>
     </div>
   );

--- a/components/dashboard/DashboardProvider.tsx
+++ b/components/dashboard/DashboardProvider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { createContext, useContext, useMemo, useState } from "react";
 import type { TreemapViewId } from "@/lib/constants";
 import type { ActivityResponse, Period, SelectedNode } from "@/lib/types";
 
@@ -34,9 +34,18 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
   const [treemapView, setTreemapView] = useState<TreemapViewId>("events");
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
 
-  useEffect(() => {
+  // Clear the selected node whenever the period or view changes so the detail
+  // panel does not show stale data. Wrapping the setters avoids the
+  // setState-in-effect anti-pattern.
+  function handleSetPeriod(p: Period) {
     setSelectedNode(null);
-  }, [period, treemapView]);
+    setPeriod(p);
+  }
+
+  function handleSetTreemapView(v: TreemapViewId) {
+    setSelectedNode(null);
+    setTreemapView(v);
+  }
 
   const query = useQuery({
     queryKey: ["activity", period],
@@ -47,9 +56,9 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
   const value = useMemo(
     () => ({
       period,
-      setPeriod,
+      setPeriod: handleSetPeriod,
       treemapView,
-      setTreemapView,
+      setTreemapView: handleSetTreemapView,
       data: query.data,
       isLoading: query.isLoading,
       isError: query.isError,

--- a/components/dashboard/DetailPanel.tsx
+++ b/components/dashboard/DetailPanel.tsx
@@ -12,9 +12,7 @@ export function DetailPanel() {
 
   if (!selectedNode) {
     return (
-      /* On mobile the empty state is compact so it doesn't push KPIs far down.
-         On xl screens it stretches to fill the sidebar column (h-full). */
-      <Card className="xl:h-full">
+      <Card>
         <CardHeader>
           <CardTitle>Details</CardTitle>
         </CardHeader>
@@ -38,7 +36,7 @@ export function DetailPanel() {
           : "This month";
 
   return (
-    <Card className="xl:h-full">
+    <Card>
       <CardHeader className="flex flex-row items-start justify-between gap-3">
         <div className="space-y-2">
           <CardTitle className="text-base text-white">

--- a/components/dashboard/DetailPanel.tsx
+++ b/components/dashboard/DetailPanel.tsx
@@ -46,9 +46,10 @@ export function DetailPanel() {
             <Badge variant="secondary">{selectedNode.meta.category}</Badge>
           ) : null}
         </div>
+        {/* size="icon" gives a 44×44 hit area (h-11 w-11) to meet touch target requirements */}
         <Button
           variant="ghost"
-          size="sm"
+          size="icon"
           className="shrink-0"
           onClick={() => setSelectedNode(null)}
           aria-label="Close details"

--- a/components/dashboard/DetailPanel.tsx
+++ b/components/dashboard/DetailPanel.tsx
@@ -12,7 +12,9 @@ export function DetailPanel() {
 
   if (!selectedNode) {
     return (
-      <Card className="h-full">
+      /* On mobile the empty state is compact so it doesn't push KPIs far down.
+         On xl screens it stretches to fill the sidebar column (h-full). */
+      <Card className="xl:h-full">
         <CardHeader>
           <CardTitle>Details</CardTitle>
         </CardHeader>
@@ -36,7 +38,7 @@ export function DetailPanel() {
           : "This month";
 
   return (
-    <Card className="h-full">
+    <Card className="xl:h-full">
       <CardHeader className="flex flex-row items-start justify-between gap-3">
         <div className="space-y-2">
           <CardTitle className="text-base text-white">

--- a/components/dashboard/NetworkTreemap.tsx
+++ b/components/dashboard/NetworkTreemap.tsx
@@ -68,14 +68,21 @@ export function NetworkTreemap() {
           </p>
         </div>
         <TreemapViewSelector />
-        <div className="flex flex-wrap gap-2">
+        <div
+          className="flex flex-wrap gap-2"
+          role="list"
+          aria-label="Category legend"
+        >
           {CATEGORY_LEGEND.map((item) => (
             <span
               key={item.key}
-              className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-zinc-300"
+              role="listitem"
+              className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-zinc-300 select-none"
             >
+              {/* Decorative color swatch — hidden from screen readers */}
               <span
-                className="h-2.5 w-2.5 rounded-full"
+                aria-hidden="true"
+                className="h-2.5 w-2.5 shrink-0 rounded-full"
                 style={{ backgroundColor: CATEGORY_COLORS[item.key] }}
               />
               {item.label}

--- a/components/dashboard/NetworkTreemap.tsx
+++ b/components/dashboard/NetworkTreemap.tsx
@@ -3,7 +3,7 @@
 import { CATEGORY_COLORS } from "@/lib/constants";
 import { useDashboard } from "@/components/dashboard/DashboardProvider";
 import { D3Treemap } from "@/components/dashboard/D3Treemap";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 
 const CATEGORY_LEGEND = [
@@ -29,11 +29,8 @@ export function NetworkTreemap() {
   if (isLoading) {
     return (
       <Card>
-        <CardHeader>
-          <CardTitle>Network Treemap</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <Skeleton className="h-[520px] w-full rounded-xl" />
+        <CardContent className="p-4 sm:p-5">
+          <Skeleton className="h-[480px] w-full rounded-xl sm:h-[560px] lg:h-[640px]" />
         </CardContent>
       </Card>
     );
@@ -42,10 +39,7 @@ export function NetworkTreemap() {
   if (isError || !data) {
     return (
       <Card>
-        <CardHeader>
-          <CardTitle>Network Treemap</CardTitle>
-        </CardHeader>
-        <CardContent>
+        <CardContent className="p-4 sm:p-5">
           <div className="flex h-[360px] items-center justify-center rounded-xl border border-red-500/20 bg-red-500/5 p-6 text-center text-sm text-red-200">
             {error?.message ?? "Unable to load treemap data."}
           </div>
@@ -58,9 +52,7 @@ export function NetworkTreemap() {
 
   return (
     <Card>
-      <CardHeader className="flex flex-col gap-4">
-        <CardTitle>Network Treemap</CardTitle>
-
+      <CardContent className="flex flex-col gap-4 p-4 sm:p-5">
         {/* Category colour legend */}
         <div
           className="flex flex-wrap gap-2"
@@ -83,12 +75,10 @@ export function NetworkTreemap() {
             </span>
           ))}
         </div>
-      </CardHeader>
 
-      <CardContent>
         <div
           key={`${period}-${treemapView}`}
-          className="h-[420px] overflow-hidden rounded-xl border border-white/5 bg-black/20 p-2 sm:h-[520px] sm:p-3 lg:h-[600px]"
+          className="h-[480px] overflow-hidden rounded-xl border border-white/5 bg-black/20 p-2 sm:h-[560px] sm:p-3 lg:h-[640px]"
         >
           <D3Treemap root={activeTreemap} onSelect={setSelectedNode} />
         </div>

--- a/components/dashboard/NetworkTreemap.tsx
+++ b/components/dashboard/NetworkTreemap.tsx
@@ -3,7 +3,6 @@
 import { CATEGORY_COLORS } from "@/lib/constants";
 import { useDashboard } from "@/components/dashboard/DashboardProvider";
 import { D3Treemap } from "@/components/dashboard/D3Treemap";
-import { TreemapViewSelector } from "@/components/dashboard/TreemapViewSelector";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -60,14 +59,9 @@ export function NetworkTreemap() {
   return (
     <Card>
       <CardHeader className="flex flex-col gap-4">
-        <div>
-          <CardTitle>Network Treemap</CardTitle>
-          <p className="text-xs text-zinc-500">
-            Switch views to explore operation types or top accounts and
-            contracts.
-          </p>
-        </div>
-        <TreemapViewSelector />
+        <CardTitle>Network Treemap</CardTitle>
+
+        {/* Category colour legend */}
         <div
           className="flex flex-wrap gap-2"
           role="list"
@@ -79,7 +73,7 @@ export function NetworkTreemap() {
               role="listitem"
               className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-zinc-300 select-none"
             >
-              {/* Decorative color swatch — hidden from screen readers */}
+              {/* Decorative colour swatch — hidden from screen readers */}
               <span
                 aria-hidden="true"
                 className="h-2.5 w-2.5 shrink-0 rounded-full"
@@ -90,10 +84,11 @@ export function NetworkTreemap() {
           ))}
         </div>
       </CardHeader>
+
       <CardContent>
         <div
           key={`${period}-${treemapView}`}
-          className="h-[420px] sm:h-[520px] lg:h-[600px] overflow-hidden rounded-xl border border-white/5 bg-black/20 p-2 sm:p-3"
+          className="h-[420px] overflow-hidden rounded-xl border border-white/5 bg-black/20 p-2 sm:h-[520px] sm:p-3 lg:h-[600px]"
         >
           <D3Treemap root={activeTreemap} onSelect={setSelectedNode} />
         </div>

--- a/components/dashboard/TreemapViewSelector.tsx
+++ b/components/dashboard/TreemapViewSelector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TREEMAP_VIEWS, type TreemapViewId } from "@/lib/constants";
+import { TREEMAP_VIEWS } from "@/lib/constants";
 import { Button } from "@/components/ui/button";
 import { useDashboard } from "@/components/dashboard/DashboardProvider";
 

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -11,8 +11,11 @@ const buttonVariants = cva(
         outline: "border border-white/15 text-zinc-200 hover:bg-white/5",
       },
       size: {
-        default: "h-9 px-4",
-        sm: "h-8 rounded-md px-3 text-xs",
+        // 44px height satisfies the minimum touch-target requirement (WCAG 2.5.5)
+        default: "h-11 px-4",
+        sm: "h-11 rounded-md px-3 text-xs",
+        // Icon-only buttons: 44×44 hit area, no padding gap compression
+        icon: "h-11 w-11 rounded-lg",
       },
     },
     defaultVariants: {

--- a/lib/hubble/fixture.ts
+++ b/lib/hubble/fixture.ts
@@ -1,0 +1,190 @@
+/**
+ * Fixture data returned by /api/activity when BigQuery credentials are absent.
+ * Used for front-end development and contributor onboarding without GCP access.
+ * Values are illustrative; they do not reflect real network state.
+ */
+
+import type { ActivityResponse } from "@/lib/types";
+
+export const fixtureResponse: ActivityResponse = {
+  period: "1d",
+  start: "2025-01-01T00:00:00.000Z",
+  end: "2025-01-01T23:59:59.999Z",
+  source: "hubble",
+  categories: [
+    { type_string: "invoke_host_function", op_count: 420000 },
+    { type_string: "payment", op_count: 180000 },
+    { type_string: "manage_sell_offer", op_count: 95000 },
+    { type_string: "path_payment_strict_receive", op_count: 62000 },
+    { type_string: "change_trust", op_count: 31000 },
+    { type_string: "manage_buy_offer", op_count: 28000 },
+    { type_string: "set_options", op_count: 15000 },
+    { type_string: "extend_footprint_ttl", op_count: 12000 },
+    { type_string: "create_account", op_count: 9000 },
+    { type_string: "manage_data", op_count: 6000 },
+    { type_string: "restore_footprint", op_count: 2000 },
+  ],
+  contracts: [
+    {
+      contract_id: "CA4HEQTL2WPEUYKYKCDOHCDNIV4QHNJ7EL4J4NQ6VADP7SYHVRYZ7AW2",
+      op_count: 88000,
+    },
+    {
+      contract_id: "CA2TZIB56KYKD46F7IFBF6XPO5TDNK6N2U6BRTGZ5AF4WUSBN6BKZMGF",
+      op_count: 54000,
+    },
+    {
+      contract_id: "CBIELTK6Y5Y5U5DT5OMY7C5QZQZQZQZQZQZQZQZQZQZQZQZQ",
+      op_count: 31000,
+    },
+  ],
+  accounts: [
+    {
+      account_id: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+      type_string: "payment",
+      op_count: 42000,
+    },
+    {
+      account_id: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNKNLXLTCV",
+      type_string: "payment",
+      op_count: 18000,
+    },
+    {
+      account_id: "GA5XIGA5C7QTPTWXQHY6MCJRMTRZDOSHR6EFIBNDQTCQHG262N4GGKTM",
+      type_string: "manage_sell_offer",
+      op_count: 27000,
+    },
+    {
+      account_id: "GDKJ3ZXB5RA2MV5T2Y3Z5D3D3VKR5F7EFRB2A3BMBC3IHGBOK5GDI2LQ",
+      type_string: "manage_buy_offer",
+      op_count: 11000,
+    },
+  ],
+  sorobanFunctions: [
+    { function_name: "swap", op_count: 95000 },
+    { function_name: "deposit", op_count: 62000 },
+    { function_name: "withdraw", op_count: 41000 },
+    { function_name: "transfer", op_count: 38000 },
+    { function_name: "approve", op_count: 22000 },
+  ],
+  sorobanFunctionContracts: [
+    {
+      function_name: "swap",
+      contract_id: "CA4HEQTL2WPEUYKYKCDOHCDNIV4QHNJ7EL4J4NQ6VADP7SYHVRYZ7AW2",
+      op_count: 55000,
+    },
+    {
+      function_name: "deposit",
+      contract_id: "CA2TZIB56KYKD46F7IFBF6XPO5TDNK6N2U6BRTGZ5AF4WUSBN6BKZMGF",
+      op_count: 38000,
+    },
+    {
+      function_name: "withdraw",
+      contract_id: "CA2TZIB56KYKD46F7IFBF6XPO5TDNK6N2U6BRTGZ5AF4WUSBN6BKZMGF",
+      op_count: 24000,
+    },
+  ],
+  kpis: {
+    totalOps: 860000,
+    sorobanShare: 0.51,
+    topCategory: "soroban",
+    activeContracts: 3,
+  },
+  treemaps: {
+    events: {
+      name: "Network Activity",
+      children: [
+        {
+          name: "Soroban Contracts",
+          value: 434000,
+          meta: { type: "category", category: "soroban" },
+          children: [
+            {
+              id: "CA4HEQTL2WPEUYKYKCDOHCDNIV4QHNJ7EL4J4NQ6VADP7SYHVRYZ7AW2",
+              name: "Soroswap",
+              value: 88000,
+              meta: {
+                type: "contract",
+                category: "soroban",
+                protocol: "Soroswap",
+              },
+            },
+            {
+              id: "CA2TZIB56KYKD46F7IFBF6XPO5TDNK6N2U6BRTGZ5AF4WUSBN6BKZMGF",
+              name: "Soroswap Pool",
+              value: 54000,
+              meta: {
+                type: "contract",
+                category: "soroban",
+                protocol: "Soroswap",
+              },
+            },
+          ],
+        },
+        {
+          name: "Payments",
+          value: 251000,
+          meta: { type: "category", category: "payments" },
+          children: [
+            {
+              id: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+              name: "Circle USDC",
+              value: 42000,
+              meta: { type: "entity", category: "payments", protocol: "Circle" },
+            },
+          ],
+        },
+        {
+          name: "DEX Trades",
+          value: 123000,
+          meta: { type: "category", category: "dex" },
+        },
+        {
+          name: "Trustlines",
+          value: 31000,
+          meta: { type: "category", category: "trustlines" },
+        },
+        {
+          name: "Account Operations",
+          value: 21000,
+          meta: { type: "category", category: "account" },
+        },
+      ],
+    },
+    actors: {
+      name: "Accounts & Contracts",
+      children: [
+        {
+          name: "Soroswap",
+          id: "CA4HEQTL2WPEUYKYKCDOHCDNIV4QHNJ7EL4J4NQ6VADP7SYHVRYZ7AW2",
+          value: 88000,
+          meta: { type: "contract", category: "soroban", protocol: "Soroswap" },
+        },
+        {
+          name: "Circle USDC",
+          id: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+          value: 42000,
+          meta: { type: "entity", category: "payments", protocol: "Circle" },
+        },
+        {
+          name: "Kraken",
+          id: "GA5XIGA5C7QTPTWXQHY6MCJRMTRZDOSHR6EFIBNDQTCQHG262N4GGKTM",
+          value: 27000,
+          meta: { type: "entity", category: "dex", protocol: "Kraken" },
+        },
+        {
+          name: "MoneyGram",
+          id: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNKNLXLTCV",
+          value: 18000,
+          meta: { type: "entity", category: "payments", protocol: "MoneyGram" },
+        },
+        {
+          name: "LOBSTR",
+          id: "GDKJ3ZXB5RA2MV5T2Y3Z5D3D3VKR5F7EFRB2A3BMBC3IHGBOK5GDI2LQ",
+          value: 11000,
+          meta: { type: "entity", category: "dex", protocol: "LOBSTR" },
+        },
+      ],
+    },
+  },
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -69,7 +69,7 @@ export interface TreemapNode {
   meta?: TreemapNodeMeta;
 }
 
-import type { TreemapViewId } from "@/lib/constants";
+
 
 export interface ActivityTreemaps {
   events: TreemapNode;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "stellar-treemap",
+  "name": "lumenmap",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "stellar-treemap",
+      "name": "lumenmap",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@google-cloud/bigquery": "^8.3.1",
         "@tanstack/react-query": "^5.101.2",
@@ -76,7 +77,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -286,10 +286,32 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -298,9 +320,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -381,9 +403,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -393,7 +415,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
@@ -405,9 +427,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -463,9 +485,9 @@
       }
     },
     "node_modules/@google-cloud/common": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-6.0.1.tgz",
-      "integrity": "sha512-1uvKzbmAWUdchIYRsg0f4rUmezOamWuVBSWAPAhnYoUE5OiPEx6v6JOxFIdr3MsrqV+6fyLV3EI1vMPlHoeRvw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-6.1.0.tgz",
+      "integrity": "sha512-Ohjxjvusr65+SiEVBrilpyn1ir9CM8ZqWjcf7bA8ph1GCunxI6bbwtcl7iGl67A7Lr4Nz7WpNzITNETwggc7pw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/projectify": "^4.0.0",
@@ -473,7 +495,7 @@
         "arrify": "^2.0.0",
         "duplexify": "^4.1.3",
         "extend": "^3.0.2",
-        "google-auth-library": "^10.0.0-rc.1",
+        "google-auth-library": "^10.6.2",
         "html-entities": "^2.5.2",
         "retry-request": "^8.0.0",
         "teeny-request": "^10.0.0"
@@ -501,9 +523,9 @@
       }
     },
     "node_modules/@google-cloud/paginator": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-6.0.2.tgz",
-      "integrity": "sha512-S60tHt4oHsVvviXY5+Ti5Reg69y5WjBglwRjJqBiVdRHxniW/L+Mc3mp7yNMcxr2Gi6DkDO4aIognNWcUxf3Vg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-6.1.0.tgz",
+      "integrity": "sha512-9bxQ/QNhcq5c6ra75khWjA5Q9UHWp0vQnhwesmqPpLLF5PxmxCIsadIA5ssLxKted4/iZ2RlRPkW/E8p68W8cg==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2"
@@ -513,9 +535,9 @@
       }
     },
     "node_modules/@google-cloud/precise-date": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-5.1.0.tgz",
-      "integrity": "sha512-Z9RVpJUZR+aMF9gPel07xbLURjdT+G4HV6x7jJhreNarQGcT/ZYn1IIfo55rd+tncGvJ4qZDfZnaF6PzqgsQkw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-5.2.0.tgz",
+      "integrity": "sha512-ckZ1elVT/JXbO4kxltiT8tumYnTXGIY7OFrDMAJyVWAte/rUYiCuH1YbaKLQrZpYDp522xgTfPqqW/VxfXFdgA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -1121,25 +1143,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@next/env": {
       "version": "16.2.10",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
@@ -1349,49 +1352,49 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
-      "integrity": "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "5.21.6",
+        "enhanced-resolve": "^5.24.1",
         "jiti": "^2.7.0",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.3.2"
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
-      "integrity": "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.3.2",
-        "@tailwindcss/oxide-darwin-arm64": "4.3.2",
-        "@tailwindcss/oxide-darwin-x64": "4.3.2",
-        "@tailwindcss/oxide-freebsd-x64": "4.3.2",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.3.2",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.3.2",
-        "@tailwindcss/oxide-linux-x64-musl": "4.3.2",
-        "@tailwindcss/oxide-wasm32-wasi": "4.3.2",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.3.2"
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.2.tgz",
-      "integrity": "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
       "cpu": [
         "arm64"
       ],
@@ -1406,9 +1409,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.2.tgz",
-      "integrity": "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
       "cpu": [
         "arm64"
       ],
@@ -1423,9 +1426,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.2.tgz",
-      "integrity": "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
       "cpu": [
         "x64"
       ],
@@ -1440,9 +1443,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.2.tgz",
-      "integrity": "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
       "cpu": [
         "x64"
       ],
@@ -1457,9 +1460,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.2.tgz",
-      "integrity": "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
       "cpu": [
         "arm"
       ],
@@ -1474,9 +1477,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.2.tgz",
-      "integrity": "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
       "cpu": [
         "arm64"
       ],
@@ -1491,9 +1494,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.2.tgz",
-      "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
       ],
@@ -1508,9 +1511,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.2.tgz",
-      "integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
       "cpu": [
         "x64"
       ],
@@ -1525,9 +1528,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.2.tgz",
-      "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
       ],
@@ -1542,9 +1545,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.2.tgz",
-      "integrity": "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -1572,9 +1575,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
-      "integrity": "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
       "cpu": [
         "arm64"
       ],
@@ -1589,9 +1592,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.2.tgz",
-      "integrity": "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
       "cpu": [
         "x64"
       ],
@@ -1606,23 +1609,23 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.2.tgz",
-      "integrity": "sha512-rjVWYCa7Ngbi5AarT6k8TkxUG3Wl1QKzHdIZVsjZSzf36Jmo2IKZt/NHRAwly8oDkbBOH0YTu+CHuf9jPxMc+g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.3.tgz",
+      "integrity": "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.3.2",
-        "@tailwindcss/oxide": "4.3.2",
-        "postcss": "^8.5.15",
-        "tailwindcss": "4.3.2"
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "postcss": "^8.5.16",
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.101.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
-      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1630,12 +1633,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.101.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
-      "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
+      "integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.101.2"
+        "@tanstack/query-core": "5.101.4"
       },
       "funding": {
         "type": "github",
@@ -1700,7 +1703,6 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1716,17 +1718,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
-      "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.63.0",
-        "@typescript-eslint/type-utils": "8.63.0",
-        "@typescript-eslint/utils": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1739,15 +1741,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.63.0",
+        "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1755,17 +1757,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
-      "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.63.0",
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1781,14 +1782,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
-      "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.63.0",
-        "@typescript-eslint/types": "^8.63.0",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1803,14 +1804,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
-      "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1821,9 +1822,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
-      "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1838,15 +1839,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
-      "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0",
-        "@typescript-eslint/utils": "8.63.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1863,9 +1864,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
-      "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1877,16 +1878,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
-      "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.63.0",
-        "@typescript-eslint/tsconfig-utils": "8.63.0",
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1915,26 +1916,26 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1957,16 +1958,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
-      "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.63.0",
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1981,13 +1982,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
-      "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2282,18 +2283,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
@@ -2305,15 +2294,26 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz",
+      "integrity": "sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "tslib": "^2.4.0"
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^2.0.0-alpha.3",
+        "@emnapi/runtime": "^2.0.0-alpha.3"
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
@@ -2359,12 +2359,11 @@
       ]
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2694,9 +2693,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.42",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
-      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.7.tgz",
+      "integrity": "sha512-APw5YuIQAg6L9w4sHDI6j26DGFJI6RpYOhnkMPdC9lWbkKvsyPHzDsve1yd73lk21yz7Y09Kci8B2Pp9FonzWA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -2728,9 +2727,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2752,9 +2751,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
-      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -2771,12 +2770,11 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.42",
-        "caniuse-lite": "^1.0.30001800",
-        "electron-to-chromium": "^1.5.387",
-        "node-releases": "^2.0.50",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -2853,9 +2851,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001803",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
-      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "funding": [
         {
           "type": "opencollective",
@@ -3181,9 +3179,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.389",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
-      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+      "version": "1.5.398",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.398.tgz",
+      "integrity": "sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -3204,9 +3202,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.6",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
-      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "version": "5.24.4",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.4.tgz",
+      "integrity": "sha512-GVoi+ICHocoOIU7qVVM48wOJziRsqrsyqlI0Ce0LdowRn6v3bcH2zUa9kp85ncx0nwIb9/HOCOLS3fdThDG/XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3326,9 +3324,9 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
-      "integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.4.0.tgz",
+      "integrity": "sha512-c/A0P0oxkACDc+cKWw8evLXK83oBKgn0qPOqCYT4x9uolpCIJAcYvJC9QYKNDRPsTeGyCrQ326jrvgZWdCdK5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3440,20 +3438,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -3631,7 +3628,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3995,9 +3991,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -4074,9 +4070,9 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
-      "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+      "integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
@@ -4235,9 +4231,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
-      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -5439,9 +5435,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.23.0.tgz",
-      "integrity": "sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.27.0.tgz",
+      "integrity": "sha512-rJicGl/3Fly/E0rOH1YmPZ6e49JCnKknh1ox1vpHnkfjujAkKA6sqUZvH3MTAaXXjgexyUwgNwTJzTtYuAFYJw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -5521,9 +5517,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -5860,13 +5856,14 @@
       }
     },
     "node_modules/own-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+      "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.6",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "object-keys": "^1.1.1",
         "safe-push-apply": "^1.0.0"
       },
@@ -5979,9 +5976,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -5999,7 +5996,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6065,7 +6062,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6075,7 +6071,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6193,9 +6188,9 @@
       }
     },
     "node_modules/retry-request": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.3.tgz",
-      "integrity": "sha512-qqoc4kkGgP9cmQDWELlOpAmfgJOg0Yi7MT82ZjiPWu451ayju4itwomjM4/dBEliify8C1b3tSaeCOldugtwPQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.4.tgz",
+      "integrity": "sha512-pI6/7eabUYkZxamkOq0g0uMxKLLGnjzhefY+vL8bVXag5rto4OU2YBTPytWLuHH7aEKD6fn7kJycQfid0Mwnkw==",
       "license": "MIT",
       "dependencies": {
         "extend": "^3.0.2",
@@ -6794,9 +6789,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
-      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6815,9 +6810,9 @@
       }
     },
     "node_modules/teeny-request": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.3.tgz",
-      "integrity": "sha512-5yDliI1uWkYPo7W+Zvrxg6YmoWuj5iC5EydewqrRTvc68nyMTZhlPPlLg6cptUGfbQAb+N9XDPDPzF6N081lug==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.4.tgz",
+      "integrity": "sha512-R1Cg4Vu0UULeDfHL/kjABLaTW++9yD/B6n2g48y5dJ04hsEaxcfmAqbNDzNsbqAYJyIpZafjklLG9YxRu9uzOg==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-proxy-agent": "^7.0.0",
@@ -6870,7 +6865,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7033,7 +7027,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7043,16 +7036,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.63.0.tgz",
-      "integrity": "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.63.0",
-        "@typescript-eslint/parser": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0",
-        "@typescript-eslint/utils": "8.63.0"
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7333,7 +7326,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary

Restructure the dashboard page layout to establish a clear hierarchy for research workflows.

### Changes

- **DashboardPage.tsx** — Restructured layout with visible h2 headings: Controls → Network Activity → Details & Metrics. Treemap now full-width (no competing sidebar). Detail panel, KPIs, and data source notice grouped in a secondary section using CSS order swapping for mobile-first layout.
- **NetworkTreemap.tsx** — Removed CardHeader/CardTitle (heading now external via section h2). Category legend preserved inline. SVG container height increased to 480/560/640px breakpoints.
- **ControlBar.tsx** — Changed sr-only h2 to visible "Controls" heading for semantic document outline.
- **DetailPanel.tsx** — Removed xl:h-full classes (no longer a sidebar).

### Acceptance Criteria

- [x] Metric and period controls are immediately discoverable
- [x] Primary visualization dominates the initial viewport
- [x] Secondary context does not compete with the chart
- [x] Heading order is semantic (h1 → h2 Controls → h2 Network Activity → h2 Details & Metrics)
- [x] Desktop and mobile layouts preserve the same task order

Closes #58