### PR TITLE
feat: define discriminated treemap metric contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,10 +196,36 @@ metrics and schema additions within v1 will be additive only.
     "activeContracts": 89
   },
   "treemaps": {
-    "events": { "name": "Network Activity", "children": [] },
-    "actors": { "name": "Accounts & Contracts", "children": [] },
-    "xlm_events": { "name": "Network Activity", "children": [] },
-    "xlm_actors": { "name": "Accounts & Contracts", "children": [] }
+    "events": {
+      "name": "Network Activity",
+      "children": [],
+      "metric": "operation_count",
+      "unit": { "kind": "count", "subject": "operation" }
+    },
+    "actors": {
+      "name": "Accounts & Contracts",
+      "children": [],
+      "metric": "operation_count",
+      "unit": { "kind": "count", "subject": "operation" }
+    },
+    "xlm_events": {
+      "name": "Network Activity",
+      "children": [],
+      "metric": "asset_volume",
+      "unit": {
+        "kind": "asset",
+        "asset": { "type": "native", "code": "XLM" }
+      }
+    },
+    "xlm_actors": {
+      "name": "Accounts & Contracts",
+      "children": [],
+      "metric": "asset_volume",
+      "unit": {
+        "kind": "asset",
+        "asset": { "type": "native", "code": "XLM" }
+      }
+    }
   },
   "categories": [],
   "contracts": [],
@@ -208,6 +234,17 @@ metrics and schema additions within v1 will be additive only.
   "sorobanFunctionContracts": []
 }
 ```
+
+Each treemap is self-describing. Count metrics use numeric node values, while
+asset-denominated metrics use decimal strings so their values cannot be treated
+as counts through the public TypeScript contract.
+
+| Metric identifier | Unit | Node value | Availability |
+| --- | --- | --- | --- |
+| `operation_count` | Operation count | `number` | Implemented |
+| `transaction_count` | Transaction count | `number` | Contract only |
+| `asset_volume` | Explicit native or issued asset | decimal `string` | XLM implemented |
+| `tvl` | Explicit valuation asset | decimal `string` | Contract only |
 
 Responses are cached for 15 minutes (`Cache-Control: public, max-age=900, s-maxage=900`).
 

--- a/app/api/activity/route.test.ts
+++ b/app/api/activity/route.test.ts
@@ -32,10 +32,32 @@ function mockActivityResponse(period: Period): ActivityResponse {
       activeContracts: 0,
     },
     treemaps: {
-      events: { name: "Events" },
-      actors: { name: "Actors" },
-      xlm_events: { name: "XLM Events" },
-      xlm_actors: { name: "XLM Actors" },
+      events: {
+        name: "Events",
+        metric: "operation_count",
+        unit: { kind: "count", subject: "operation" },
+      },
+      actors: {
+        name: "Actors",
+        metric: "operation_count",
+        unit: { kind: "count", subject: "operation" },
+      },
+      xlm_events: {
+        name: "XLM Events",
+        metric: "asset_volume",
+        unit: {
+          kind: "asset",
+          asset: { type: "native", code: "XLM" },
+        },
+      },
+      xlm_actors: {
+        name: "XLM Actors",
+        metric: "asset_volume",
+        unit: {
+          kind: "asset",
+          asset: { type: "native", code: "XLM" },
+        },
+      },
     },
   };
 }

--- a/components/dashboard/DashboardProvider.tsx
+++ b/components/dashboard/DashboardProvider.tsx
@@ -6,7 +6,7 @@ import type { TreemapViewId } from "@/lib/constants";
 import type {
   ActivityResponse,
   ApiErrorResponse,
-  MetricId,
+  DashboardMetricId,
   Period,
   SelectedNode,
 } from "@/lib/types";
@@ -16,8 +16,8 @@ interface DashboardContextValue {
   setPeriod: (period: Period) => void;
   treemapView: TreemapViewId;
   setTreemapView: (view: TreemapViewId) => void;
-  metric: MetricId;
-  setMetric: (metric: MetricId) => void;
+  metric: DashboardMetricId;
+  setMetric: (metric: DashboardMetricId) => void;
   data?: ActivityResponse;
   isLoading: boolean;
   isError: boolean;
@@ -40,7 +40,7 @@ async function fetchActivity(period: Period): Promise<ActivityResponse> {
 export function DashboardProvider({ children }: { children: React.ReactNode }) {
   const [period, setPeriod] = useState<Period>("1d");
   const [treemapView, setTreemapView] = useState<TreemapViewId>("events");
-  const [metric, setMetric] = useState<MetricId>("ops");
+  const [metric, setMetric] = useState<DashboardMetricId>("ops");
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
 
   const handleSetPeriod = useCallback((newPeriod: Period) => {
@@ -53,7 +53,7 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
     setTreemapView(newView);
   }, []);
 
-  const handleSetMetric = useCallback((newMetric: MetricId) => {
+  const handleSetMetric = useCallback((newMetric: DashboardMetricId) => {
     setSelectedNode(null);
     setMetric(newMetric);
   }, []);

--- a/components/dashboard/NetworkTreemap.tsx
+++ b/components/dashboard/NetworkTreemap.tsx
@@ -7,6 +7,7 @@ import { TreemapViewSelector } from "@/components/dashboard/TreemapViewSelector"
 import { TreemapMetricSelector } from "@/components/dashboard/TreemapMetricSelector";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import type { TreemapNode } from "@/lib/types";
 
 const CATEGORY_LEGEND = [
   { key: "soroban", label: "Soroban" },
@@ -16,6 +17,17 @@ const CATEGORY_LEGEND = [
   { key: "account", label: "Account Ops" },
   { key: "other", label: "Other" },
 ];
+
+function toChartNode(node: TreemapNode<number | string>): TreemapNode {
+  const { value, children, ...rest } = node;
+  return {
+    ...rest,
+    ...(value !== undefined ? { value: Number(value) } : {}),
+    ...(children
+      ? { children: children.map(toChartNode) }
+      : {}),
+  };
+}
 
 export function NetworkTreemap() {
   const {
@@ -57,9 +69,10 @@ export function NetworkTreemap() {
     );
   }
 
-  const activeTreemap = metric === "xlm_volume"
+  const activePayload = metric === "xlm_volume"
     ? data.treemaps[`xlm_${treemapView}` as keyof typeof data.treemaps]
     : data.treemaps[treemapView];
+  const activeTreemap = toChartNode(activePayload);
 
   return (
     <Card>

--- a/lib/entities/build-treemap.ts
+++ b/lib/entities/build-treemap.ts
@@ -7,14 +7,17 @@ import { getDisplayName, lookupEntity } from "@/lib/entities/registry";
 import type {
   AccountRow,
   ActivityKpis,
+  ActivityTreemaps,
   CategoryRow,
   ContractRow,
   EntityInfo,
   SorobanFunctionContractRow,
   SorobanFunctionRow,
   TreemapNode,
-  MetricId,
 } from "@/lib/types";
+import { OPERATION_COUNT_UNIT, XLM_ASSET_UNIT } from "@/lib/types";
+
+type BuildMetricId = "ops" | "xlm_volume";
 
 interface BuildTreemapInput {
   categories: CategoryRow[];
@@ -38,7 +41,7 @@ function getGroupForType(type: string): string {
   return TYPE_TO_GROUP[type] ?? "other";
 }
 
-function getGroupTotals(categories: CategoryRow[], metric: MetricId): Map<string, number> {
+function getGroupTotals(categories: CategoryRow[], metric: BuildMetricId): Map<string, number> {
   const totals = new Map<string, number>();
 
   for (const row of categories) {
@@ -53,7 +56,7 @@ function getGroupTotals(categories: CategoryRow[], metric: MetricId): Map<string
 function buildContractLeaves(
   contracts: ContractRow[],
   labels?: BuildTreemapInput["labels"],
-  metric: MetricId = "ops",
+  metric: BuildMetricId = "ops",
 ): TreemapNode[] {
   if (metric === "xlm_volume") return []; // No XLM volume for contracts
 
@@ -110,7 +113,7 @@ function buildAccountLeaves(
   accounts: AccountRow[],
   group: string,
   labels?: BuildTreemapInput["labels"],
-  metric: MetricId = "ops",
+  metric: BuildMetricId = "ops",
 ): TreemapNode[] {
   const filtered = accounts.filter(
     (row) => getGroupForType(row.type_string) === group,
@@ -140,7 +143,7 @@ function buildAccountLeavesForEventType(
   eventType: string,
   group: string,
   labels?: BuildTreemapInput["labels"],
-  metric: MetricId = "ops",
+  metric: BuildMetricId = "ops",
 ): TreemapNode[] {
   const rows = accounts
     .filter((row) => row.type_string === eventType)
@@ -162,7 +165,7 @@ function buildContractLeavesForFunction(
   rows: SorobanFunctionContractRow[],
   functionName: string,
   labels?: BuildTreemapInput["labels"],
-  metric: MetricId = "ops",
+  metric: BuildMetricId = "ops",
 ): TreemapNode[] {
   if (metric === "xlm_volume") return []; // Soroban doesn't have XLM volume mapped here
 
@@ -178,7 +181,7 @@ function buildContractLeavesForFunction(
   );
 }
 
-function buildSorobanFunctionLeaves(input: BuildTreemapInput, metric: MetricId = "ops"): TreemapNode[] {
+function buildSorobanFunctionLeaves(input: BuildTreemapInput, metric: BuildMetricId = "ops"): TreemapNode[] {
   if (metric === "xlm_volume") return []; // No XLM volume for Soroban functions here
 
   const color = CATEGORY_COLORS.soroban;
@@ -212,7 +215,7 @@ function buildSorobanFunctionLeaves(input: BuildTreemapInput, metric: MetricId =
 function buildTypeLeaves(
   input: BuildTreemapInput,
   group: string,
-  metric: MetricId = "ops",
+  metric: BuildMetricId = "ops",
 ): TreemapNode[] {
   if (group === "soroban") {
     return buildSorobanFunctionLeaves(input, metric);
@@ -257,7 +260,7 @@ function buildTypeLeaves(
 function buildCategoryGroupChildren(
   group: string,
   input: BuildTreemapInput,
-  metric: MetricId = "ops",
+  metric: BuildMetricId = "ops",
 ): TreemapNode[] {
   if (group === "soroban") {
     return buildContractLeaves(input.contracts, input.labels, metric);
@@ -280,8 +283,8 @@ function buildCategoryGroupChildren(
 
 function buildGroupedTreemap(
   input: BuildTreemapInput,
-  metric: MetricId,
-  getCategoryChildren: (group: string, metric: MetricId) => TreemapNode[],
+  metric: BuildMetricId,
+  getCategoryChildren: (group: string, metric: BuildMetricId) => TreemapNode[],
 ): TreemapNode {
   const groupTotals = getGroupTotals(input.categories, metric);
   const totalOps = categoriesTotal(input.categories, metric);
@@ -324,22 +327,58 @@ function buildGroupedTreemap(
   };
 }
 
-export function buildEventTypeTreemap(input: BuildTreemapInput, metric: MetricId = "ops"): TreemapNode {
+export function buildEventTypeTreemap(input: BuildTreemapInput, metric: BuildMetricId = "ops"): TreemapNode {
   return buildGroupedTreemap(input, metric, (group, m) => buildTypeLeaves(input, group, m));
 }
 
-export function buildActorTreemap(input: BuildTreemapInput, metric: MetricId = "ops"): TreemapNode {
+export function buildActorTreemap(input: BuildTreemapInput, metric: BuildMetricId = "ops"): TreemapNode {
   return buildGroupedTreemap(input, metric, (group, m) =>
     buildCategoryGroupChildren(group, input, m),
   );
 }
 
-export function buildAllTreemaps(input: BuildTreemapInput) {
+function serializeAssetValues(node: TreemapNode): TreemapNode<string> {
+  const { value, children, ...rest } = node;
   return {
-    events: buildEventTypeTreemap(input, "ops"),
-    actors: buildActorTreemap(input, "ops"),
-    xlm_events: buildEventTypeTreemap(input, "xlm_volume"),
-    xlm_actors: buildActorTreemap(input, "xlm_volume"),
+    ...rest,
+    ...(value !== undefined ? { value: String(value) } : {}),
+    ...(children
+      ? { children: children.map(serializeAssetValues) }
+      : {}),
+  };
+}
+
+export function buildAllTreemaps(input: BuildTreemapInput): ActivityTreemaps {
+  const eventOperations = buildEventTypeTreemap(input, "ops");
+  const actorOperations = buildActorTreemap(input, "ops");
+  const eventXlmVolume = serializeAssetValues(
+    buildEventTypeTreemap(input, "xlm_volume"),
+  );
+  const actorXlmVolume = serializeAssetValues(
+    buildActorTreemap(input, "xlm_volume"),
+  );
+
+  return {
+    events: {
+      ...eventOperations,
+      metric: "operation_count",
+      unit: OPERATION_COUNT_UNIT,
+    },
+    actors: {
+      ...actorOperations,
+      metric: "operation_count",
+      unit: OPERATION_COUNT_UNIT,
+    },
+    xlm_events: {
+      ...eventXlmVolume,
+      metric: "asset_volume",
+      unit: XLM_ASSET_UNIT,
+    },
+    xlm_actors: {
+      ...actorXlmVolume,
+      metric: "asset_volume",
+      unit: XLM_ASSET_UNIT,
+    },
   };
 }
 
@@ -370,7 +409,7 @@ export function buildKpis(
   };
 }
 
-function categoriesTotal(categories: CategoryRow[], metric: MetricId): number {
+function categoriesTotal(categories: CategoryRow[], metric: BuildMetricId): number {
   return categories.reduce((sum, row) => {
     const value = metric === "xlm_volume" ? (row.xlm_volume ?? 0) : row.op_count;
     return sum + value;

--- a/lib/entities/metric-contract.test.ts
+++ b/lib/entities/metric-contract.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { buildAllTreemaps } from "@/lib/entities/build-treemap";
+import {
+  OPERATION_COUNT_UNIT,
+  XLM_ASSET_UNIT,
+  type MetricId,
+  type TreemapPayload,
+} from "@/lib/types";
+
+const supportedMetrics: MetricId[] = [
+  "operation_count",
+  "transaction_count",
+  "asset_volume",
+  "tvl",
+];
+
+const validCountPayload: TreemapPayload<"operation_count"> = {
+  name: "Operations",
+  value: 12,
+  metric: "operation_count",
+  unit: OPERATION_COUNT_UNIT,
+};
+
+const invalidCountUnit: TreemapPayload<"operation_count"> = {
+  name: "Operations",
+  value: 12,
+  metric: "operation_count",
+  // @ts-expect-error Operation counts cannot carry asset units.
+  unit: XLM_ASSET_UNIT,
+};
+
+const invalidAssetValue: TreemapPayload<"asset_volume"> = {
+  name: "Volume",
+  metric: "asset_volume",
+  unit: XLM_ASSET_UNIT,
+  // @ts-expect-error Asset-denominated values serialize as decimal strings.
+  value: 12,
+};
+
+describe("treemap metric contract", () => {
+  test("defines all supported metric identifiers", () => {
+    assert.deepEqual(supportedMetrics, [
+      "operation_count",
+      "transaction_count",
+      "asset_volume",
+      "tvl",
+    ]);
+    assert.equal(validCountPayload.unit.kind, "count");
+    assert.ok(invalidCountUnit);
+    assert.ok(invalidAssetValue);
+  });
+
+  test("serializes operation and asset treemaps with self-describing units", () => {
+    const treemaps = buildAllTreemaps({
+      categories: [
+        { type_string: "payment", op_count: 7, xlm_volume: 12.5 },
+      ],
+      contracts: [],
+      accounts: [],
+      sorobanFunctions: [],
+      sorobanFunctionContracts: [],
+    });
+
+    assert.deepEqual(treemaps.events.unit, OPERATION_COUNT_UNIT);
+    assert.equal(treemaps.events.metric, "operation_count");
+    assert.equal(treemaps.events.value, 7);
+
+    const serializedOperations = JSON.parse(
+      JSON.stringify(treemaps.events),
+    ) as {
+      metric: string;
+      unit: { kind: string; subject: string };
+      value: number;
+    };
+    assert.equal(serializedOperations.metric, "operation_count");
+    assert.equal(serializedOperations.unit.kind, "count");
+    assert.equal(serializedOperations.unit.subject, "operation");
+    assert.equal(typeof serializedOperations.value, "number");
+
+    assert.deepEqual(treemaps.xlm_events.unit, XLM_ASSET_UNIT);
+    assert.equal(treemaps.xlm_events.metric, "asset_volume");
+    assert.equal(treemaps.xlm_events.value, "12.5");
+
+    const serialized = JSON.parse(JSON.stringify(treemaps.xlm_events)) as {
+      metric: string;
+      unit: { kind: string; asset: { code: string } };
+      value: string;
+    };
+    assert.equal(serialized.metric, "asset_volume");
+    assert.equal(serialized.unit.kind, "asset");
+    assert.equal(serialized.unit.asset.code, "XLM");
+    assert.equal(typeof serialized.value, "string");
+  });
+});

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,7 +2,59 @@ export type Period = "1d" | "7d" | "30d" | "month";
 
 export type DataSource = "hubble";
 
-export type MetricId = "ops" | "xlm_volume";
+/** Stable identifiers used by the public treemap contract. */
+export type MetricId =
+  | "operation_count"
+  | "transaction_count"
+  | "asset_volume"
+  | "tvl";
+
+/** Internal selector values for the two metrics currently backed by queries. */
+export type DashboardMetricId = "ops" | "xlm_volume";
+
+export type CountUnit =
+  | { kind: "count"; subject: "operation" }
+  | { kind: "count"; subject: "transaction" };
+
+export type AssetIdentity =
+  | { type: "native"; code: "XLM" }
+  | { type: "issued"; code: string; issuer: string };
+
+export type AssetUnit = { kind: "asset"; asset: AssetIdentity };
+
+/**
+ * A discriminated metric contract keeps identifiers, serialized values, and
+ * units coupled. Asset amounts are strings so consumers cannot accidentally
+ * treat them as count values.
+ */
+export type MetricContract =
+  | {
+      metric: "operation_count";
+      value: number;
+      unit: { kind: "count"; subject: "operation" };
+    }
+  | {
+      metric: "transaction_count";
+      value: number;
+      unit: { kind: "count"; subject: "transaction" };
+    }
+  | { metric: "asset_volume"; value: string; unit: AssetUnit }
+  | { metric: "tvl"; value: string; unit: AssetUnit };
+
+type MetricVariant<M extends MetricId> = Extract<MetricContract, { metric: M }>;
+
+export type MetricValue<M extends MetricId> = MetricVariant<M>["value"];
+export type MetricUnit<M extends MetricId> = MetricVariant<M>["unit"];
+
+export const OPERATION_COUNT_UNIT = {
+  kind: "count",
+  subject: "operation",
+} as const satisfies MetricUnit<"operation_count">;
+
+export const XLM_ASSET_UNIT = {
+  kind: "asset",
+  asset: { type: "native", code: "XLM" },
+} as const satisfies MetricUnit<"asset_volume">;
 
 export type TreemapNodeType =
   | "root"
@@ -65,20 +117,25 @@ export interface TreemapNodeMeta {
   eventType?: string;
 }
 
-export interface TreemapNode {
+export interface TreemapNode<TValue extends number | string = number> {
   id?: string;
   name: string;
-  value?: number;
+  value?: TValue;
   color?: string;
-  children?: TreemapNode[];
+  children?: TreemapNode<TValue>[];
   meta?: TreemapNodeMeta;
 }
 
+export type TreemapPayload<M extends MetricId> = TreemapNode<MetricValue<M>> & {
+  metric: M;
+  unit: MetricUnit<M>;
+};
+
 export interface ActivityTreemaps {
-  events: TreemapNode;
-  actors: TreemapNode;
-  xlm_events: TreemapNode;
-  xlm_actors: TreemapNode;
+  events: TreemapPayload<"operation_count">;
+  actors: TreemapPayload<"operation_count">;
+  xlm_events: TreemapPayload<"asset_volume">;
+  xlm_actors: TreemapPayload<"asset_volume">;
 }
 
 export interface ActivityResponse {


### PR DESCRIPTION
Closes #16

## Summary
- introduces a discriminated public metric contract for `operation_count`, `transaction_count`, `asset_volume`, and `tvl`
- couples every metric identifier to its valid unit and serialized value representation
- adds `metric` and `unit` directly to existing treemap roots so the v1 response remains additive
- keeps operation-count nodes numeric and serializes asset-denominated node values as decimal strings
- preserves the existing dashboard by normalizing public values at the chart boundary
- documents the response contract and current/planned metric availability

## Why
Treemap nodes previously exposed an unqualified numeric `value`, so consumers could not determine whether a value represented operations or an asset amount without relying on labels or response keys. The discriminated contract makes invalid metric-unit and count-asset combinations fail type checking.

## Verification
- `npm test` — 23 tests passed, including serialized operation/asset payloads and type-level invalid combinations
- `npm run typecheck`
- `npm run lint`
- `npm run build`