### PR TITLE
feat: add metric provenance metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,76 @@ metrics and schema additions within v1 will be additive only.
       }
     }
   },
+  "metricProvenance": {
+    "operation_count": {
+      "metric": "operation_count",
+      "methodology": {
+        "id": "operations",
+        "version": "1.0.0",
+        "href": "docs/metric-methodology.md#operations"
+      },
+      "source": {
+        "provider": "hubble",
+        "dataset": "crypto-stellar.crypto_stellar_dbt",
+        "tables": [
+          "enriched_history_operations",
+          "enriched_history_operations_soroban",
+          "hourly_soroban_fee_agg_contract"
+        ]
+      },
+      "aggregation": {
+        "kind": "count",
+        "function": "COUNT(*)",
+        "granularity": "selected_period",
+        "dimensions": ["type_string"]
+      },
+      "coverage": {
+        "network": "stellar_mainnet",
+        "constraints": [
+          {
+            "kind": "partial_period",
+            "completenessField": "isPeriodComplete"
+          },
+          {
+            "kind": "top_n",
+            "appliesTo": "account_children",
+            "limit": 70,
+            "partitionBy": "type_string"
+          }
+        ]
+      }
+    },
+    "asset_volume": {
+      "metric": "asset_volume",
+      "methodology": {
+        "id": "payment-volume",
+        "version": "1.0.0",
+        "href": "docs/metric-methodology.md#payment-volume"
+      },
+      "source": {
+        "provider": "hubble",
+        "dataset": "crypto-stellar.crypto_stellar_dbt",
+        "tables": ["enriched_history_operations"]
+      },
+      "aggregation": {
+        "kind": "sum",
+        "field": "amount",
+        "granularity": "selected_period",
+        "dimensions": ["type_string", "asset_identity"]
+      },
+      "coverage": {
+        "network": "stellar_mainnet",
+        "constraints": [
+          {
+            "kind": "filter",
+            "field": "asset_type",
+            "operator": "equals",
+            "value": "native"
+          }
+        ]
+      }
+    }
+  },
   "categories": [],
   "contracts": [],
   "accounts": [],
@@ -245,6 +315,12 @@ as counts through the public TypeScript contract.
 | `transaction_count` | Transaction count | `number` | Contract only |
 | `asset_volume` | Explicit native or issued asset | decimal `string` | XLM implemented |
 | `tvl` | Explicit valuation asset | decimal `string` | Contract only |
+
+Use a treemap's `metric` as the key into `metricProvenance`. Coverage
+constraints are discriminated by `kind`; the serialized response can represent
+inclusive time bounds, partial periods, source lag, filters, and top-N limits
+without requiring consumers to parse prose. The example abbreviates repeated
+coverage constraints; the response includes every applicable constraint.
 
 Responses are cached for 15 minutes (`Cache-Control: public, max-age=900, s-maxage=900`).
 

--- a/README.md
+++ b/README.md
@@ -196,10 +196,36 @@ metrics and schema additions within v1 will be additive only.
     "activeContracts": 89
   },
   "treemaps": {
-    "events": { "name": "Network Activity", "children": [] },
-    "actors": { "name": "Accounts & Contracts", "children": [] },
-    "xlm_events": { "name": "Network Activity", "children": [] },
-    "xlm_actors": { "name": "Accounts & Contracts", "children": [] }
+    "events": {
+      "name": "Network Activity",
+      "children": [],
+      "metric": "operation_count",
+      "unit": { "kind": "count", "subject": "operation" }
+    },
+    "actors": {
+      "name": "Accounts & Contracts",
+      "children": [],
+      "metric": "operation_count",
+      "unit": { "kind": "count", "subject": "operation" }
+    },
+    "xlm_events": {
+      "name": "Network Activity",
+      "children": [],
+      "metric": "asset_volume",
+      "unit": {
+        "kind": "asset",
+        "asset": { "type": "native", "code": "XLM" }
+      }
+    },
+    "xlm_actors": {
+      "name": "Accounts & Contracts",
+      "children": [],
+      "metric": "asset_volume",
+      "unit": {
+        "kind": "asset",
+        "asset": { "type": "native", "code": "XLM" }
+      }
+    }
   },
   "categories": [],
   "contracts": [],
@@ -208,6 +234,17 @@ metrics and schema additions within v1 will be additive only.
   "sorobanFunctionContracts": []
 }
 ```
+
+Each treemap is self-describing. Count metrics use numeric node values, while
+asset-denominated metrics use decimal strings so their values cannot be treated
+as counts through the public TypeScript contract.
+
+| Metric identifier | Unit | Node value | Availability |
+| --- | --- | --- | --- |
+| `operation_count` | Operation count | `number` | Implemented |
+| `transaction_count` | Transaction count | `number` | Contract only |
+| `asset_volume` | Explicit native or issued asset | decimal `string` | XLM implemented |
+| `tvl` | Explicit valuation asset | decimal `string` | Contract only |
 
 Responses are cached for 15 minutes (`Cache-Control: public, max-age=900, s-maxage=900`).
 

--- a/app/api/activity/route.test.ts
+++ b/app/api/activity/route.test.ts
@@ -32,10 +32,32 @@ function mockActivityResponse(period: Period): ActivityResponse {
       activeContracts: 0,
     },
     treemaps: {
-      events: { name: "Events" },
-      actors: { name: "Actors" },
-      xlm_events: { name: "XLM Events" },
-      xlm_actors: { name: "XLM Actors" },
+      events: {
+        name: "Events",
+        metric: "operation_count",
+        unit: { kind: "count", subject: "operation" },
+      },
+      actors: {
+        name: "Actors",
+        metric: "operation_count",
+        unit: { kind: "count", subject: "operation" },
+      },
+      xlm_events: {
+        name: "XLM Events",
+        metric: "asset_volume",
+        unit: {
+          kind: "asset",
+          asset: { type: "native", code: "XLM" },
+        },
+      },
+      xlm_actors: {
+        name: "XLM Actors",
+        metric: "asset_volume",
+        unit: {
+          kind: "asset",
+          asset: { type: "native", code: "XLM" },
+        },
+      },
     },
   };
 }

--- a/app/api/activity/route.test.ts
+++ b/app/api/activity/route.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./_handler";
 import { GET as v1GET } from "../v1/activity/route";
 import type { ActivityResponse, Period } from "@/lib/types";
+import { buildActivityMetricProvenance } from "@/lib/metrics/provenance";
 
 const supportedPeriods: Period[] = ["1d", "7d", "30d", "month"];
 
@@ -59,6 +60,7 @@ function mockActivityResponse(period: Period): ActivityResponse {
         },
       },
     },
+    metricProvenance: buildActivityMetricProvenance(),
   };
 }
 
@@ -106,7 +108,12 @@ describe("GET /api/activity and /api/v1/activity", () => {
 
     assert.equal(response.status, 200);
     assert.deepEqual(calls, ["1d"]);
-    assert.equal((await response.json()).period, "1d");
+    const body = (await response.json()) as ActivityResponse;
+    assert.equal(body.period, "1d");
+    assert.equal(
+      body.metricProvenance[body.treemaps.events.metric].methodology.id,
+      "operations",
+    );
   });
 
   test("returns 200 for each supported period", async () => {

--- a/components/dashboard/DashboardProvider.tsx
+++ b/components/dashboard/DashboardProvider.tsx
@@ -6,7 +6,7 @@ import type { TreemapViewId } from "@/lib/constants";
 import type {
   ActivityResponse,
   ApiErrorResponse,
-  MetricId,
+  DashboardMetricId,
   Period,
   SelectedNode,
 } from "@/lib/types";
@@ -16,8 +16,8 @@ interface DashboardContextValue {
   setPeriod: (period: Period) => void;
   treemapView: TreemapViewId;
   setTreemapView: (view: TreemapViewId) => void;
-  metric: MetricId;
-  setMetric: (metric: MetricId) => void;
+  metric: DashboardMetricId;
+  setMetric: (metric: DashboardMetricId) => void;
   data?: ActivityResponse;
   isLoading: boolean;
   isError: boolean;
@@ -40,7 +40,7 @@ async function fetchActivity(period: Period): Promise<ActivityResponse> {
 export function DashboardProvider({ children }: { children: React.ReactNode }) {
   const [period, setPeriod] = useState<Period>("1d");
   const [treemapView, setTreemapView] = useState<TreemapViewId>("events");
-  const [metric, setMetric] = useState<MetricId>("ops");
+  const [metric, setMetric] = useState<DashboardMetricId>("ops");
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
 
   const handleSetPeriod = useCallback((newPeriod: Period) => {
@@ -53,7 +53,7 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
     setTreemapView(newView);
   }, []);
 
-  const handleSetMetric = useCallback((newMetric: MetricId) => {
+  const handleSetMetric = useCallback((newMetric: DashboardMetricId) => {
     setSelectedNode(null);
     setMetric(newMetric);
   }, []);

--- a/components/dashboard/NetworkTreemap.tsx
+++ b/components/dashboard/NetworkTreemap.tsx
@@ -7,6 +7,7 @@ import { TreemapViewSelector } from "@/components/dashboard/TreemapViewSelector"
 import { TreemapMetricSelector } from "@/components/dashboard/TreemapMetricSelector";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import type { TreemapNode } from "@/lib/types";
 
 const CATEGORY_LEGEND = [
   { key: "soroban", label: "Soroban" },
@@ -16,6 +17,17 @@ const CATEGORY_LEGEND = [
   { key: "account", label: "Account Ops" },
   { key: "other", label: "Other" },
 ];
+
+function toChartNode(node: TreemapNode<number | string>): TreemapNode {
+  const { value, children, ...rest } = node;
+  return {
+    ...rest,
+    ...(value !== undefined ? { value: Number(value) } : {}),
+    ...(children
+      ? { children: children.map(toChartNode) }
+      : {}),
+  };
+}
 
 export function NetworkTreemap() {
   const {
@@ -57,9 +69,10 @@ export function NetworkTreemap() {
     );
   }
 
-  const activeTreemap = metric === "xlm_volume"
+  const activePayload = metric === "xlm_volume"
     ? data.treemaps[`xlm_${treemapView}` as keyof typeof data.treemaps]
     : data.treemaps[treemapView];
+  const activeTreemap = toChartNode(activePayload);
 
   return (
     <Card>

--- a/docs/metric-methodology.md
+++ b/docs/metric-methodology.md
@@ -49,6 +49,8 @@ explorer statistic.
 
 ### Operations
 
+**Methodology ID:** `operations` · **Version:** `1.0.0`
+
 | Property | Canonical definition |
 | --- | --- |
 | **Unit** | One Stellar operation record. |
@@ -60,6 +62,8 @@ explorer statistic.
 | **Limitations** | This is not a transaction count: one transaction can contain multiple operations. Category mapping is a presentation grouping and can change only with a methodology version change. Subject to the common partial-period, freshness, cache, and inclusive-boundary limitations. |
 
 ### Transactions
+
+**Methodology ID:** `transactions` · **Version:** `1.0.0`
 
 | Property | Canonical definition |
 | --- | --- |
@@ -76,6 +80,8 @@ particular, summing operation-type counts must never be labelled “transactions
 
 ### Payment volume
 
+**Methodology ID:** `payment-volume` · **Version:** `1.0.0`
+
 | Property | Canonical definition |
 | --- | --- |
 | **Unit** | Amount in the payment asset's native units, reported separately for each asset identity. |
@@ -87,6 +93,8 @@ particular, summing operation-type counts must never be labelled “transactions
 | **Limitations** | **Not currently returned by the dashboard or API.** Asset units have different meanings and decimals; displaying “total volume” across XLM, issued assets, or other assets is prohibited unless a separately documented versioned normalization specifies the price source, quote currency, timestamp, missing-price policy, and aggregation. Hubble freshness and partial-period limits apply. |
 
 ### Total value locked (TVL)
+
+**Methodology ID:** `total-value-locked` · **Version:** `1.0.0`
 
 | Property | Canonical definition |
 | --- | --- |

--- a/lib/entities/build-treemap.ts
+++ b/lib/entities/build-treemap.ts
@@ -7,14 +7,17 @@ import { getDisplayName, lookupEntity } from "@/lib/entities/registry";
 import type {
   AccountRow,
   ActivityKpis,
+  ActivityTreemaps,
   CategoryRow,
   ContractRow,
   EntityInfo,
   SorobanFunctionContractRow,
   SorobanFunctionRow,
   TreemapNode,
-  MetricId,
 } from "@/lib/types";
+import { OPERATION_COUNT_UNIT, XLM_ASSET_UNIT } from "@/lib/types";
+
+type BuildMetricId = "ops" | "xlm_volume";
 
 interface BuildTreemapInput {
   categories: CategoryRow[];
@@ -38,7 +41,7 @@ function getGroupForType(type: string): string {
   return TYPE_TO_GROUP[type] ?? "other";
 }
 
-function getGroupTotals(categories: CategoryRow[], metric: MetricId): Map<string, number> {
+function getGroupTotals(categories: CategoryRow[], metric: BuildMetricId): Map<string, number> {
   const totals = new Map<string, number>();
 
   for (const row of categories) {
@@ -53,7 +56,7 @@ function getGroupTotals(categories: CategoryRow[], metric: MetricId): Map<string
 function buildContractLeaves(
   contracts: ContractRow[],
   labels?: BuildTreemapInput["labels"],
-  metric: MetricId = "ops",
+  metric: BuildMetricId = "ops",
 ): TreemapNode[] {
   if (metric === "xlm_volume") return []; // No XLM volume for contracts
 
@@ -110,7 +113,7 @@ function buildAccountLeaves(
   accounts: AccountRow[],
   group: string,
   labels?: BuildTreemapInput["labels"],
-  metric: MetricId = "ops",
+  metric: BuildMetricId = "ops",
 ): TreemapNode[] {
   const filtered = accounts.filter(
     (row) => getGroupForType(row.type_string) === group,
@@ -140,7 +143,7 @@ function buildAccountLeavesForEventType(
   eventType: string,
   group: string,
   labels?: BuildTreemapInput["labels"],
-  metric: MetricId = "ops",
+  metric: BuildMetricId = "ops",
 ): TreemapNode[] {
   const rows = accounts
     .filter((row) => row.type_string === eventType)
@@ -162,7 +165,7 @@ function buildContractLeavesForFunction(
   rows: SorobanFunctionContractRow[],
   functionName: string,
   labels?: BuildTreemapInput["labels"],
-  metric: MetricId = "ops",
+  metric: BuildMetricId = "ops",
 ): TreemapNode[] {
   if (metric === "xlm_volume") return []; // Soroban doesn't have XLM volume mapped here
 
@@ -178,7 +181,7 @@ function buildContractLeavesForFunction(
   );
 }
 
-function buildSorobanFunctionLeaves(input: BuildTreemapInput, metric: MetricId = "ops"): TreemapNode[] {
+function buildSorobanFunctionLeaves(input: BuildTreemapInput, metric: BuildMetricId = "ops"): TreemapNode[] {
   if (metric === "xlm_volume") return []; // No XLM volume for Soroban functions here
 
   const color = CATEGORY_COLORS.soroban;
@@ -212,7 +215,7 @@ function buildSorobanFunctionLeaves(input: BuildTreemapInput, metric: MetricId =
 function buildTypeLeaves(
   input: BuildTreemapInput,
   group: string,
-  metric: MetricId = "ops",
+  metric: BuildMetricId = "ops",
 ): TreemapNode[] {
   if (group === "soroban") {
     return buildSorobanFunctionLeaves(input, metric);
@@ -257,7 +260,7 @@ function buildTypeLeaves(
 function buildCategoryGroupChildren(
   group: string,
   input: BuildTreemapInput,
-  metric: MetricId = "ops",
+  metric: BuildMetricId = "ops",
 ): TreemapNode[] {
   if (group === "soroban") {
     return buildContractLeaves(input.contracts, input.labels, metric);
@@ -280,8 +283,8 @@ function buildCategoryGroupChildren(
 
 function buildGroupedTreemap(
   input: BuildTreemapInput,
-  metric: MetricId,
-  getCategoryChildren: (group: string, metric: MetricId) => TreemapNode[],
+  metric: BuildMetricId,
+  getCategoryChildren: (group: string, metric: BuildMetricId) => TreemapNode[],
 ): TreemapNode {
   const groupTotals = getGroupTotals(input.categories, metric);
   const totalOps = categoriesTotal(input.categories, metric);
@@ -324,22 +327,58 @@ function buildGroupedTreemap(
   };
 }
 
-export function buildEventTypeTreemap(input: BuildTreemapInput, metric: MetricId = "ops"): TreemapNode {
+export function buildEventTypeTreemap(input: BuildTreemapInput, metric: BuildMetricId = "ops"): TreemapNode {
   return buildGroupedTreemap(input, metric, (group, m) => buildTypeLeaves(input, group, m));
 }
 
-export function buildActorTreemap(input: BuildTreemapInput, metric: MetricId = "ops"): TreemapNode {
+export function buildActorTreemap(input: BuildTreemapInput, metric: BuildMetricId = "ops"): TreemapNode {
   return buildGroupedTreemap(input, metric, (group, m) =>
     buildCategoryGroupChildren(group, input, m),
   );
 }
 
-export function buildAllTreemaps(input: BuildTreemapInput) {
+function serializeAssetValues(node: TreemapNode): TreemapNode<string> {
+  const { value, children, ...rest } = node;
   return {
-    events: buildEventTypeTreemap(input, "ops"),
-    actors: buildActorTreemap(input, "ops"),
-    xlm_events: buildEventTypeTreemap(input, "xlm_volume"),
-    xlm_actors: buildActorTreemap(input, "xlm_volume"),
+    ...rest,
+    ...(value !== undefined ? { value: String(value) } : {}),
+    ...(children
+      ? { children: children.map(serializeAssetValues) }
+      : {}),
+  };
+}
+
+export function buildAllTreemaps(input: BuildTreemapInput): ActivityTreemaps {
+  const eventOperations = buildEventTypeTreemap(input, "ops");
+  const actorOperations = buildActorTreemap(input, "ops");
+  const eventXlmVolume = serializeAssetValues(
+    buildEventTypeTreemap(input, "xlm_volume"),
+  );
+  const actorXlmVolume = serializeAssetValues(
+    buildActorTreemap(input, "xlm_volume"),
+  );
+
+  return {
+    events: {
+      ...eventOperations,
+      metric: "operation_count",
+      unit: OPERATION_COUNT_UNIT,
+    },
+    actors: {
+      ...actorOperations,
+      metric: "operation_count",
+      unit: OPERATION_COUNT_UNIT,
+    },
+    xlm_events: {
+      ...eventXlmVolume,
+      metric: "asset_volume",
+      unit: XLM_ASSET_UNIT,
+    },
+    xlm_actors: {
+      ...actorXlmVolume,
+      metric: "asset_volume",
+      unit: XLM_ASSET_UNIT,
+    },
   };
 }
 
@@ -370,7 +409,7 @@ export function buildKpis(
   };
 }
 
-function categoriesTotal(categories: CategoryRow[], metric: MetricId): number {
+function categoriesTotal(categories: CategoryRow[], metric: BuildMetricId): number {
   return categories.reduce((sum, row) => {
     const value = metric === "xlm_volume" ? (row.xlm_volume ?? 0) : row.op_count;
     return sum + value;

--- a/lib/entities/metric-contract.test.ts
+++ b/lib/entities/metric-contract.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { buildAllTreemaps } from "@/lib/entities/build-treemap";
+import {
+  OPERATION_COUNT_UNIT,
+  XLM_ASSET_UNIT,
+  type MetricId,
+  type TreemapPayload,
+} from "@/lib/types";
+
+const supportedMetrics: MetricId[] = [
+  "operation_count",
+  "transaction_count",
+  "asset_volume",
+  "tvl",
+];
+
+const validCountPayload: TreemapPayload<"operation_count"> = {
+  name: "Operations",
+  value: 12,
+  metric: "operation_count",
+  unit: OPERATION_COUNT_UNIT,
+};
+
+const invalidCountUnit: TreemapPayload<"operation_count"> = {
+  name: "Operations",
+  value: 12,
+  metric: "operation_count",
+  // @ts-expect-error Operation counts cannot carry asset units.
+  unit: XLM_ASSET_UNIT,
+};
+
+const invalidAssetValue: TreemapPayload<"asset_volume"> = {
+  name: "Volume",
+  metric: "asset_volume",
+  unit: XLM_ASSET_UNIT,
+  // @ts-expect-error Asset-denominated values serialize as decimal strings.
+  value: 12,
+};
+
+describe("treemap metric contract", () => {
+  test("defines all supported metric identifiers", () => {
+    assert.deepEqual(supportedMetrics, [
+      "operation_count",
+      "transaction_count",
+      "asset_volume",
+      "tvl",
+    ]);
+    assert.equal(validCountPayload.unit.kind, "count");
+    assert.ok(invalidCountUnit);
+    assert.ok(invalidAssetValue);
+  });
+
+  test("serializes operation and asset treemaps with self-describing units", () => {
+    const treemaps = buildAllTreemaps({
+      categories: [
+        { type_string: "payment", op_count: 7, xlm_volume: 12.5 },
+      ],
+      contracts: [],
+      accounts: [],
+      sorobanFunctions: [],
+      sorobanFunctionContracts: [],
+    });
+
+    assert.deepEqual(treemaps.events.unit, OPERATION_COUNT_UNIT);
+    assert.equal(treemaps.events.metric, "operation_count");
+    assert.equal(treemaps.events.value, 7);
+
+    const serializedOperations = JSON.parse(
+      JSON.stringify(treemaps.events),
+    ) as {
+      metric: string;
+      unit: { kind: string; subject: string };
+      value: number;
+    };
+    assert.equal(serializedOperations.metric, "operation_count");
+    assert.equal(serializedOperations.unit.kind, "count");
+    assert.equal(serializedOperations.unit.subject, "operation");
+    assert.equal(typeof serializedOperations.value, "number");
+
+    assert.deepEqual(treemaps.xlm_events.unit, XLM_ASSET_UNIT);
+    assert.equal(treemaps.xlm_events.metric, "asset_volume");
+    assert.equal(treemaps.xlm_events.value, "12.5");
+
+    const serialized = JSON.parse(JSON.stringify(treemaps.xlm_events)) as {
+      metric: string;
+      unit: { kind: string; asset: { code: string } };
+      value: string;
+    };
+    assert.equal(serialized.metric, "asset_volume");
+    assert.equal(serialized.unit.kind, "asset");
+    assert.equal(serialized.unit.asset.code, "XLM");
+    assert.equal(typeof serialized.value, "string");
+  });
+});

--- a/lib/hubble/activity.ts
+++ b/lib/hubble/activity.ts
@@ -25,6 +25,7 @@ import {
   resolveEntityLabels,
 } from "@/lib/entities/resolve-labels";
 import { resolvePeriod } from "@/lib/periods";
+import { buildActivityMetricProvenance } from "@/lib/metrics/provenance";
 import type { ActivityResponse, Period } from "@/lib/types";
 
 async function runQuery<T>(
@@ -110,7 +111,7 @@ export async function getActivityData(period: Period): Promise<ActivityResponse>
   }
 
   const range = resolvePeriod(period);
-  const cacheKey = `activity:v10:${period}:${range.start.toISOString()}`;
+  const cacheKey = `activity:v11:${period}:${range.start.toISOString()}`;
 
   const cached = getCached<ActivityResponse>(cacheKey);
   if (cached) {
@@ -143,6 +144,7 @@ export async function getActivityData(period: Period): Promise<ActivityResponse>
     sorobanFunctionContracts: raw.sorobanFunctionContracts,
     kpis,
     treemaps,
+    metricProvenance: buildActivityMetricProvenance(),
   };
 
   setCache(cacheKey, response);

--- a/lib/metrics/provenance.test.ts
+++ b/lib/metrics/provenance.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  TOP_ACCOUNTS_PER_TYPE,
+  TOP_CONTRACT_LIMIT,
+} from "@/lib/constants";
+import { buildActivityMetricProvenance } from "@/lib/metrics/provenance";
+
+describe("activity metric provenance", () => {
+  test("links operation count to its public source and methodology", () => {
+    const provenance = buildActivityMetricProvenance().operation_count;
+
+    assert.equal(provenance.metric, "operation_count");
+    assert.deepEqual(provenance.methodology, {
+      id: "operations",
+      version: "1.0.0",
+      href: "docs/metric-methodology.md#operations",
+    });
+    assert.equal(provenance.source.provider, "hubble");
+    assert.equal(
+      provenance.source.dataset,
+      "crypto-stellar.crypto_stellar_dbt",
+    );
+    assert.deepEqual(provenance.aggregation, {
+      kind: "count",
+      function: "COUNT(*)",
+      granularity: "selected_period",
+      dimensions: ["type_string"],
+    });
+  });
+
+  test("represents coverage limits as discriminated data", () => {
+    const constraints =
+      buildActivityMetricProvenance().operation_count.coverage.constraints;
+
+    assert.ok(
+      constraints.some(
+        (constraint) =>
+          constraint.kind === "top_n" &&
+          constraint.appliesTo === "account_children" &&
+          constraint.limit === TOP_ACCOUNTS_PER_TYPE &&
+          constraint.partitionBy === "type_string",
+      ),
+    );
+    assert.ok(
+      constraints.some(
+        (constraint) =>
+          constraint.kind === "top_n" &&
+          constraint.appliesTo === "contract_children" &&
+          constraint.limit === TOP_CONTRACT_LIMIT,
+      ),
+    );
+    assert.ok(
+      constraints.some(
+        (constraint) =>
+          constraint.kind === "partial_period" &&
+          constraint.completenessField === "isPeriodComplete",
+      ),
+    );
+  });
+
+  test("serializes without deployment credentials or query text", () => {
+    const serialized = JSON.stringify(buildActivityMetricProvenance());
+    const sensitiveDetail =
+      /credential|service[_ -]?account|project[_ -]?id|\bSELECT\b|GOOGLE_APPLICATION/i;
+
+    assert.doesNotMatch(serialized, sensitiveDetail);
+    assert.match(serialized, /enriched_history_operations/);
+    assert.match(serialized, /payment-volume/);
+  });
+});

--- a/lib/metrics/provenance.ts
+++ b/lib/metrics/provenance.ts
@@ -1,0 +1,114 @@
+import {
+  TOP_ACCOUNTS_PER_TYPE,
+  TOP_CONTRACT_LIMIT,
+  TOP_CONTRACTS_PER_FUNCTION,
+  TOP_SOROBAN_FUNCTIONS,
+} from "@/lib/constants";
+import type {
+  ActivityMetricProvenance,
+  CoverageConstraint,
+} from "@/lib/types";
+
+const COMMON_COVERAGE: CoverageConstraint[] = [
+  {
+    kind: "time_bounds",
+    semantics: "inclusive",
+    startField: "start",
+    endField: "end",
+  },
+  { kind: "partial_period", completenessField: "isPeriodComplete" },
+  { kind: "source_lag", watermarkField: "sourceTimestamp" },
+];
+
+export function buildActivityMetricProvenance(): ActivityMetricProvenance {
+  return {
+    operation_count: {
+      metric: "operation_count",
+      methodology: {
+        id: "operations",
+        version: "1.0.0",
+        href: "docs/metric-methodology.md#operations",
+      },
+      source: {
+        provider: "hubble",
+        dataset: "crypto-stellar.crypto_stellar_dbt",
+        tables: [
+          "enriched_history_operations",
+          "enriched_history_operations_soroban",
+          "hourly_soroban_fee_agg_contract",
+        ],
+      },
+      aggregation: {
+        kind: "count",
+        function: "COUNT(*)",
+        granularity: "selected_period",
+        dimensions: ["type_string"],
+      },
+      coverage: {
+        network: "stellar_mainnet",
+        constraints: [
+          ...COMMON_COVERAGE,
+          {
+            kind: "top_n",
+            appliesTo: "account_children",
+            limit: TOP_ACCOUNTS_PER_TYPE,
+            partitionBy: "type_string",
+          },
+          {
+            kind: "top_n",
+            appliesTo: "contract_children",
+            limit: TOP_CONTRACT_LIMIT,
+          },
+          {
+            kind: "top_n",
+            appliesTo: "soroban_function_children",
+            limit: TOP_SOROBAN_FUNCTIONS,
+          },
+          {
+            kind: "top_n",
+            appliesTo: "contracts_per_function",
+            limit: TOP_CONTRACTS_PER_FUNCTION,
+            partitionBy: "function_name",
+          },
+        ],
+      },
+    },
+    asset_volume: {
+      metric: "asset_volume",
+      methodology: {
+        id: "payment-volume",
+        version: "1.0.0",
+        href: "docs/metric-methodology.md#payment-volume",
+      },
+      source: {
+        provider: "hubble",
+        dataset: "crypto-stellar.crypto_stellar_dbt",
+        tables: ["enriched_history_operations"],
+      },
+      aggregation: {
+        kind: "sum",
+        field: "amount",
+        granularity: "selected_period",
+        dimensions: ["type_string", "asset_identity"],
+      },
+      coverage: {
+        network: "stellar_mainnet",
+        constraints: [
+          ...COMMON_COVERAGE,
+          {
+            kind: "filter",
+            field: "asset_type",
+            operator: "equals",
+            value: "native",
+          },
+          {
+            kind: "top_n",
+            appliesTo: "account_children",
+            limit: TOP_ACCOUNTS_PER_TYPE,
+            partitionBy: "type_string",
+          },
+        ],
+      },
+    },
+  };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,7 +2,59 @@ export type Period = "1d" | "7d" | "30d" | "month";
 
 export type DataSource = "hubble";
 
-export type MetricId = "ops" | "xlm_volume";
+/** Stable identifiers used by the public treemap contract. */
+export type MetricId =
+  | "operation_count"
+  | "transaction_count"
+  | "asset_volume"
+  | "tvl";
+
+/** Internal selector values for the two metrics currently backed by queries. */
+export type DashboardMetricId = "ops" | "xlm_volume";
+
+export type CountUnit =
+  | { kind: "count"; subject: "operation" }
+  | { kind: "count"; subject: "transaction" };
+
+export type AssetIdentity =
+  | { type: "native"; code: "XLM" }
+  | { type: "issued"; code: string; issuer: string };
+
+export type AssetUnit = { kind: "asset"; asset: AssetIdentity };
+
+/**
+ * A discriminated metric contract keeps identifiers, serialized values, and
+ * units coupled. Asset amounts are strings so consumers cannot accidentally
+ * treat them as count values.
+ */
+export type MetricContract =
+  | {
+      metric: "operation_count";
+      value: number;
+      unit: { kind: "count"; subject: "operation" };
+    }
+  | {
+      metric: "transaction_count";
+      value: number;
+      unit: { kind: "count"; subject: "transaction" };
+    }
+  | { metric: "asset_volume"; value: string; unit: AssetUnit }
+  | { metric: "tvl"; value: string; unit: AssetUnit };
+
+type MetricVariant<M extends MetricId> = Extract<MetricContract, { metric: M }>;
+
+export type MetricValue<M extends MetricId> = MetricVariant<M>["value"];
+export type MetricUnit<M extends MetricId> = MetricVariant<M>["unit"];
+
+export const OPERATION_COUNT_UNIT = {
+  kind: "count",
+  subject: "operation",
+} as const satisfies MetricUnit<"operation_count">;
+
+export const XLM_ASSET_UNIT = {
+  kind: "asset",
+  asset: { type: "native", code: "XLM" },
+} as const satisfies MetricUnit<"asset_volume">;
 
 export type TreemapNodeType =
   | "root"
@@ -65,20 +117,25 @@ export interface TreemapNodeMeta {
   eventType?: string;
 }
 
-export interface TreemapNode {
+export interface TreemapNode<TValue extends number | string = number> {
   id?: string;
   name: string;
-  value?: number;
+  value?: TValue;
   color?: string;
-  children?: TreemapNode[];
+  children?: TreemapNode<TValue>[];
   meta?: TreemapNodeMeta;
 }
 
+export type TreemapPayload<M extends MetricId> = TreemapNode<MetricValue<M>> & {
+  metric: M;
+  unit: MetricUnit<M>;
+};
+
 export interface ActivityTreemaps {
-  events: TreemapNode;
-  actors: TreemapNode;
-  xlm_events: TreemapNode;
-  xlm_actors: TreemapNode;
+  events: TreemapPayload<"operation_count">;
+  actors: TreemapPayload<"operation_count">;
+  xlm_events: TreemapPayload<"asset_volume">;
+  xlm_actors: TreemapPayload<"asset_volume">;
 }
 
 export interface ActivityResponse {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -46,6 +46,107 @@ type MetricVariant<M extends MetricId> = Extract<MetricContract, { metric: M }>;
 export type MetricValue<M extends MetricId> = MetricVariant<M>["value"];
 export type MetricUnit<M extends MetricId> = MetricVariant<M>["unit"];
 
+export type MetricMethodology = {
+  operation_count: {
+    id: "operations";
+    version: "1.0.0";
+    href: "docs/metric-methodology.md#operations";
+  };
+  transaction_count: {
+    id: "transactions";
+    version: "1.0.0";
+    href: "docs/metric-methodology.md#transactions";
+  };
+  asset_volume: {
+    id: "payment-volume";
+    version: "1.0.0";
+    href: "docs/metric-methodology.md#payment-volume";
+  };
+  tvl: {
+    id: "total-value-locked";
+    version: "1.0.0";
+    href: "docs/metric-methodology.md#total-value-locked-tvl";
+  };
+};
+
+export type MetricAggregation = {
+  operation_count: {
+    kind: "count";
+    function: "COUNT(*)";
+    granularity: "selected_period";
+    dimensions: ["type_string"];
+  };
+  transaction_count: {
+    kind: "count_distinct";
+    field: "transaction_hash";
+    granularity: "selected_period";
+    dimensions: [];
+  };
+  asset_volume: {
+    kind: "sum";
+    field: "amount";
+    granularity: "selected_period";
+    dimensions: ["type_string", "asset_identity"];
+  };
+  tvl: {
+    kind: "snapshot_sum";
+    granularity: "point_in_time";
+    dimensions: ["protocol", "asset_identity"];
+  };
+};
+
+export type CoverageConstraint =
+  | {
+      kind: "time_bounds";
+      semantics: "inclusive";
+      startField: "start";
+      endField: "end";
+    }
+  | {
+      kind: "partial_period";
+      completenessField: "isPeriodComplete";
+    }
+  | {
+      kind: "source_lag";
+      watermarkField: "sourceTimestamp";
+    }
+  | {
+      kind: "top_n";
+      appliesTo:
+        | "account_children"
+        | "contract_children"
+        | "soroban_function_children"
+        | "contracts_per_function";
+      limit: number;
+      partitionBy?: "type_string" | "function_name";
+    }
+  | {
+      kind: "filter";
+      field: "asset_type";
+      operator: "equals";
+      value: "native";
+    };
+
+export type MetricProvenance<M extends MetricId> = {
+  metric: M;
+  methodology: MetricMethodology[M];
+  source: {
+    provider: "hubble";
+    dataset: "crypto-stellar.crypto_stellar_dbt";
+    tables: string[];
+  };
+  aggregation: MetricAggregation[M];
+  coverage: {
+    network: "stellar_mainnet";
+    constraints: CoverageConstraint[];
+  };
+};
+
+export interface ActivityMetricProvenance {
+  operation_count: MetricProvenance<"operation_count">;
+  asset_volume: MetricProvenance<"asset_volume">;
+}
+
 export const OPERATION_COUNT_UNIT = {
   kind: "count",
   subject: "operation",
@@ -152,6 +253,7 @@ export interface ActivityResponse {
   sorobanFunctionContracts: SorobanFunctionContractRow[];
   kpis: ActivityKpis;
   treemaps: ActivityTreemaps;
+  metricProvenance: ActivityMetricProvenance;
 }
 
 export interface ApiErrorResponse {


### PR DESCRIPTION
Closes #17

> Depends on #196. This branch builds on the discriminated metric contract from #16; that commit will drop from the diff when #196 merges.

## Summary
- adds typed response-level `metricProvenance` keyed by treemap metric id
- records public Hubble dataset/tables and machine-readable aggregation semantics
- links each returned metric to a methodology id, version, and documentation section
- expresses time bounds, partial periods, source lag, filters, and top-N limits as discriminated constraints
- bumps the activity cache schema version and documents the public response
- excludes credentials, project IDs, and query text

## Verification
- `npm test` — 26 tests
- `npm run typecheck`
- `npm run lint`
- `npm run build`