### PR TITLE
Add sortable data-table alternative for the active visualization

### DIFF
--- a/components/dashboard/D3Treemap.tsx
+++ b/components/dashboard/D3Treemap.tsx
@@ -5,6 +5,7 @@ import { hierarchy, treemap, treemapSquarify } from "d3-hierarchy";
 import type { HierarchyNode } from "d3-hierarchy";
 import { ChevronRight } from "lucide-react";
 import { CATEGORY_COLORS } from "@/lib/constants";
+import { resolveActiveLevel, getNodeValue } from "@/lib/entities/treemap-level";
 import { PATTERN_DEFS, PATTERN_OPACITY, getCategoryPatternId } from "@/lib/treemap-patterns";
 import type { SelectedNode, TreemapNode } from "@/lib/types";
 import { getMetricUnit } from "@/lib/metrics/units";
@@ -20,6 +21,8 @@ import { useDashboard } from "@/components/dashboard/DashboardProvider";
 interface D3TreemapProps {
   root: TreemapNode;
   onSelect: (node: SelectedNode) => void;
+  path: TreemapNode[];
+  onPathChange: (path: TreemapNode[]) => void;
 }
 
 interface LayoutNode extends HierarchyNode<TreemapNode> {
@@ -42,9 +45,6 @@ function resolveColor(node: TreemapNode): string {
   return CATEGORY_COLORS.other;
 }
 
-function getNodeValue(node: TreemapNode): number {
-  return node.value ?? node.meta?.opCount ?? 0;
-}
 
 interface TooltipData {
   x: number;
@@ -56,11 +56,11 @@ interface TooltipData {
   unit: string;
 }
 
-export function D3Treemap({ root, onSelect }: D3TreemapProps) {
+export function D3Treemap({ root, onSelect, path, onPathChange }: D3TreemapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState({ width: 400, height: 400 });
-  const [path, setPath] = useState<TreemapNode[]>([]);
+  // path lifted to DashboardProvider so the data table stays in sync
   const [hoveredId, setHoveredId] = useState<string | null>(null);
   const [tooltip, setTooltip] = useState<TooltipData | null>(null);
   const reducedMotion = useReducedMotion();
@@ -90,20 +90,10 @@ export function D3Treemap({ root, onSelect }: D3TreemapProps) {
   const metricUnit = metricUnitInfo.unitLabel;
   const metricUnitSuffix = metricUnitInfo.unitSuffix;
 
-  const currentNode = path.length > 0 ? path[path.length - 1] : root;
-  const levelTotal = useMemo(() => {
-    const children = currentNode.children ?? [];
-    if (children.length > 0) {
-      const childSum = children.reduce(
-        (sum, child) => sum + getNodeValue(child),
-        0,
-      );
-      if (childSum > 0) {
-        return childSum;
-      }
-    }
-    return getNodeValue(currentNode);
-  }, [currentNode]);
+  const { currentNode, levelTotal } = useMemo(
+    () => resolveActiveLevel(root, path),
+    [root, path],
+  );
 
   useEffect(() => {
     const element = chartRef.current;
@@ -203,12 +193,12 @@ export function D3Treemap({ root, onSelect }: D3TreemapProps) {
         const newPath = [root, ...path, original];
         const pathString = newPath.map((n) => n.name).join(" > ");
         announce(`${selectionText} Drilled down. New path: ${pathString}.`);
-        setPath((current) => [...current, original]);
+        onPathChange([...path, original]);
       } else {
         announce(selectionText);
       }
     },
-    [levelTotal, onSelect, tileLookup, path, root, announce],
+    [levelTotal, onSelect, tileLookup, path, root, announce, onPathChange],
   );
 
   const navigateTo = useCallback(
@@ -236,12 +226,12 @@ export function D3Treemap({ root, onSelect }: D3TreemapProps) {
       );
 
       if (index < 0) {
-        setPath([]);
+        onPathChange([]);
         return;
       }
-      setPath((current) => current.slice(0, index + 1));
+      onPathChange(path.slice(0, index + 1));
     },
-    [root, path, announce],
+    [root, path, announce, onPathChange],
   );
 
   

--- a/components/dashboard/DashboardProvider.tsx
+++ b/components/dashboard/DashboardProvider.tsx
@@ -37,6 +37,9 @@ interface DashboardContextValue {
   /** Active search focus used to open treemap context. */
   focusRequest: SearchResult | null;
   selectSearchResult: (result: SearchResult) => void;
+  /** Breadcrumb path for the active treemap level (shared with data table). */
+  activeLevelPath: TreemapNode[];
+  setActiveLevelPath: (path: TreemapNode[]) => void;
 }
 
 const DashboardContext = createContext<DashboardContextValue | null>(null);
@@ -105,22 +108,26 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
   const [metric, setMetricState] = useState<DashboardMetricId>("ops");
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
   const [focusRequest, setFocusRequest] = useState<SearchResult | null>(null);
+  const [activeLevelPath, setActiveLevelPath] = useState<TreemapNode[]>([]);
 
   const handleSetPeriod = useCallback((newPeriod: Period) => {
     setSelectedNode(null);
     setFocusRequest(null);
+    setActiveLevelPath([]);
     setPeriodState(newPeriod);
   }, []);
 
   const handleSetTreemapView = useCallback((newView: TreemapViewId) => {
     setSelectedNode(null);
     setFocusRequest(null);
+    setActiveLevelPath([]);
     setTreemapViewState(newView);
   }, []);
 
   const handleSetMetric = useCallback((newMetric: DashboardMetricId) => {
     setSelectedNode(null);
     setFocusRequest(null);
+    setActiveLevelPath([]);
     setMetricState(newMetric);
   }, []);
 
@@ -157,6 +164,8 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
       setSelectedNode,
       focusRequest,
       selectSearchResult,
+      activeLevelPath,
+      setActiveLevelPath,
     }),
     [
       period,
@@ -174,6 +183,7 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
       selectedNode,
       focusRequest,
       selectSearchResult,
+      activeLevelPath,
     ],
   );
 

--- a/components/dashboard/NetworkTreemap.tsx
+++ b/components/dashboard/NetworkTreemap.tsx
@@ -8,6 +8,8 @@ import { PATTERN_DEFS, PATTERN_OPACITY, getCategoryPatternId } from "@/lib/treem
 import { useDashboard } from "@/components/dashboard/DashboardProvider";
 import { D3Treemap } from "@/components/dashboard/D3Treemap";
 import { ExportControls } from "@/components/dashboard/ExportControls";
+import { TreemapDataTable } from "@/components/dashboard/TreemapDataTable";
+import { resolveActiveLevel } from "@/lib/entities/treemap-level";
 import { TreemapViewSelector } from "@/components/dashboard/TreemapViewSelector";
 import { TreemapMetricSelector } from "@/components/dashboard/TreemapMetricSelector";
 import { Button } from "@/components/ui/button";
@@ -90,6 +92,9 @@ export function NetworkTreemap() {
     treemapView,
     metric,
     setSelectedNode,
+    selectedNode,
+    activeLevelPath,
+    setActiveLevelPath,
   } = useDashboard();
   const [isRetrying, setIsRetrying] = useState(false);
   const [excludedCategories, setExcludedCategories] = useState<Set<string>>(
@@ -257,7 +262,7 @@ export function NetworkTreemap() {
           {filterAnnouncement}
         </div>
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-6">
         {isLoading ? (
           <div data-treemap-container="true"
             className={CHART_FRAME_CLASS}>
@@ -290,7 +295,12 @@ export function NetworkTreemap() {
         ) : (
           <div key={`${period}-${treemapView}-${metric}-${excludedCategories.size}`} className={CHART_FRAME_CLASS}>
             {!isEmpty ? (
-              <D3Treemap root={filteredTreemap} onSelect={setSelectedNode} />
+              <D3Treemap
+                root={filteredTreemap}
+                onSelect={setSelectedNode}
+                path={activeLevelPath}
+                onPathChange={setActiveLevelPath}
+              />
             ) : (
               <div
                 role="status"
@@ -321,6 +331,20 @@ export function NetworkTreemap() {
             )}
           </div>
         )}
+        {!isLoading && !isError && filteredTreemap
+          ? (() => {
+              const level = resolveActiveLevel(filteredTreemap, activeLevelPath);
+              return (
+                <TreemapDataTable
+                  levelName={level.currentNode.name}
+                  nodes={level.children}
+                  levelTotal={level.levelTotal}
+                  selectedNode={selectedNode}
+                  onSelect={setSelectedNode}
+                />
+              );
+            })()
+          : null}
       </CardContent>
     </Card>
   );

--- a/components/dashboard/TreemapDataTable.tsx
+++ b/components/dashboard/TreemapDataTable.tsx
@@ -59,6 +59,46 @@ function toSelectedNode(node: TreemapNode, share: number): SelectedNode {
   };
 }
 
+
+function SortableHeader({
+  label,
+  sortByKey,
+  sortKey,
+  sortDirection,
+  onSort,
+}: {
+  label: string;
+  sortByKey: SortKey;
+  sortKey: SortKey;
+  sortDirection: SortDirection;
+  onSort: (key: SortKey) => void;
+}) {
+  const ariaSort: "ascending" | "descending" | "none" =
+    sortByKey !== sortKey ? "none" : sortDirection === "asc" ? "ascending" : "descending";
+
+  const icon =
+    sortByKey !== sortKey ? (
+      <ArrowUpDown className="h-3 w-3 text-zinc-600" aria-hidden="true" />
+    ) : sortDirection === "asc" ? (
+      <ArrowUp className="h-3 w-3 text-white" aria-hidden="true" />
+    ) : (
+      <ArrowDown className="h-3 w-3 text-white" aria-hidden="true" />
+    );
+
+  return (
+    <th scope="col" aria-sort={ariaSort} className="p-0">
+      <button
+        type="button"
+        onClick={() => onSort(sortByKey)}
+        className="flex w-full items-center gap-1 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-400 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-stellar-light"
+      >
+        {label}
+        {icon}
+      </button>
+    </th>
+  );
+}
+
 export function TreemapDataTable({
   levelName,
   nodes,
@@ -107,36 +147,6 @@ export function TreemapDataTable({
     setSortDirection("desc");
   };
 
-  const ariaSort = (key: SortKey): "ascending" | "descending" | "none" => {
-    if (key !== sortKey) return "none";
-    return sortDirection === "asc" ? "ascending" : "descending";
-  };
-
-  const renderSortIcon = (key: SortKey) => {
-    if (key !== sortKey) {
-      return <ArrowUpDown className="h-3 w-3 text-zinc-600" aria-hidden="true" />;
-    }
-    return sortDirection === "asc" ? (
-      <ArrowUp className="h-3 w-3 text-white" aria-hidden="true" />
-    ) : (
-      <ArrowDown className="h-3 w-3 text-white" aria-hidden="true" />
-    );
-  };
-
-  function SortableHeader({ label, sortByKey }: { label: string; sortByKey: SortKey }) {
-    return (
-      <th scope="col" aria-sort={ariaSort(sortByKey)} className="p-0">
-        <button
-          type="button"
-          onClick={() => handleSort(sortByKey)}
-          className="flex w-full items-center gap-1 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-400 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-stellar-light"
-        >
-          {label}
-          {renderSortIcon(sortByKey)}
-        </button>
-      </th>
-    );
-  }
 
   if (nodes.length === 0) {
     return (
@@ -156,16 +166,16 @@ export function TreemapDataTable({
         <table className="w-full min-w-[640px] border-collapse text-sm">
           <thead>
             <tr className="border-b border-white/10">
-              <SortableHeader label="Name" sortByKey="name" />
-              <SortableHeader label="Type" sortByKey="type" />
-              <SortableHeader label="Value" sortByKey="value" />
+              <SortableHeader label="Name" sortByKey="name" sortKey={sortKey} sortDirection={sortDirection} onSort={handleSort} />
+              <SortableHeader label="Type" sortByKey="type" sortKey={sortKey} sortDirection={sortDirection} onSort={handleSort} />
+              <SortableHeader label="Value" sortByKey="value" sortKey={sortKey} sortDirection={sortDirection} onSort={handleSort} />
               <th
                 scope="col"
                 className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-400"
               >
                 Unit
               </th>
-              <SortableHeader label="Share" sortByKey="share" />
+              <SortableHeader label="Share" sortByKey="share" sortKey={sortKey} sortDirection={sortDirection} onSort={handleSort} />
               <th
                 scope="col"
                 className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-400"

--- a/components/dashboard/TreemapDataTable.tsx
+++ b/components/dashboard/TreemapDataTable.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { getNodeValue } from "@/lib/entities/treemap-level";
+import type { SelectedNode, TreemapNode } from "@/lib/types";
+import { cn, formatExactNumber, formatPercent } from "@/lib/utils";
+
+interface TreemapDataTableProps {
+  levelName: string;
+  nodes: TreemapNode[];
+  levelTotal: number;
+  selectedNode: SelectedNode | null;
+  onSelect: (node: SelectedNode) => void;
+}
+
+type SortKey = "name" | "type" | "value" | "share";
+type SortDirection = "asc" | "desc";
+
+const TYPE_LABELS: Record<string, string> = {
+  root: "Root",
+  category: "Category",
+  entity: "Operation type",
+  contract: "Contract",
+  account: "Account",
+};
+
+const UNIT_LABEL = "ops";
+
+function getNodeIdentity(node: TreemapNode): string {
+  return node.meta?.id ?? node.id ?? node.name;
+}
+
+function getNodeType(node: TreemapNode): string {
+  return TYPE_LABELS[node.meta?.type ?? ""] ?? "Other";
+}
+
+function getCoverageLabel(node: TreemapNode): string {
+  const childCount = node.children?.length ?? node.meta?.childCount;
+  if (childCount) {
+    return `${childCount} sub-item${childCount === 1 ? "" : "s"}`;
+  }
+  return "Leaf";
+}
+
+function toSelectedNode(node: TreemapNode, share: number): SelectedNode {
+  return {
+    name: node.name,
+    value: getNodeValue(node),
+    share,
+    meta: {
+      ...node.meta,
+      type: node.meta?.type ?? "entity",
+      id: node.meta?.id ?? node.id,
+      opCount: getNodeValue(node),
+      childCount: node.children?.length ?? node.meta?.childCount,
+    },
+  };
+}
+
+export function TreemapDataTable({
+  levelName,
+  nodes,
+  levelTotal,
+  selectedNode,
+  onSelect,
+}: TreemapDataTableProps) {
+  const [sortKey, setSortKey] = useState<SortKey>("value");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+
+  const rows = useMemo(() => {
+    const withShare = nodes.map((node) => {
+      const value = getNodeValue(node);
+      const share = levelTotal > 0 ? (value / levelTotal) * 100 : 0;
+      return { node, value, share };
+    });
+
+    return [...withShare].sort((a, b) => {
+      let comparison = 0;
+      if (sortKey === "name") {
+        comparison = a.node.name.localeCompare(b.node.name);
+      } else if (sortKey === "type") {
+        comparison = getNodeType(a.node).localeCompare(getNodeType(b.node));
+      } else if (sortKey === "value") {
+        comparison = a.value - b.value;
+      } else {
+        comparison = a.share - b.share;
+      }
+
+      if (comparison === 0) {
+        // Deterministic tiebreaker so equal values always land in the
+        // same order regardless of the original array order.
+        comparison = a.node.name.localeCompare(b.node.name);
+      }
+
+      return sortDirection === "asc" ? comparison : -comparison;
+    });
+  }, [nodes, levelTotal, sortKey, sortDirection]);
+
+  const handleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDirection((current) => (current === "asc" ? "desc" : "asc"));
+      return;
+    }
+    setSortKey(key);
+    setSortDirection("desc");
+  };
+
+  const ariaSort = (key: SortKey): "ascending" | "descending" | "none" => {
+    if (key !== sortKey) return "none";
+    return sortDirection === "asc" ? "ascending" : "descending";
+  };
+
+  const renderSortIcon = (key: SortKey) => {
+    if (key !== sortKey) {
+      return <ArrowUpDown className="h-3 w-3 text-zinc-600" aria-hidden="true" />;
+    }
+    return sortDirection === "asc" ? (
+      <ArrowUp className="h-3 w-3 text-white" aria-hidden="true" />
+    ) : (
+      <ArrowDown className="h-3 w-3 text-white" aria-hidden="true" />
+    );
+  };
+
+  function SortableHeader({ label, sortByKey }: { label: string; sortByKey: SortKey }) {
+    return (
+      <th scope="col" aria-sort={ariaSort(sortByKey)} className="p-0">
+        <button
+          type="button"
+          onClick={() => handleSort(sortByKey)}
+          className="flex w-full items-center gap-1 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-400 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-stellar-light"
+        >
+          {label}
+          {renderSortIcon(sortByKey)}
+        </button>
+      </th>
+    );
+  }
+
+  if (nodes.length === 0) {
+    return (
+      <div className="rounded-xl border border-white/5 bg-black/20 p-6 text-center text-sm text-zinc-500">
+        No rows to display for {levelName}.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-zinc-500">
+        Exact values for <span className="text-zinc-300">{levelName}</span>{" "}
+        ({formatExactNumber(levelTotal)} {UNIT_LABEL} total)
+      </p>
+      <div className="overflow-x-auto rounded-xl border border-white/5 bg-black/20">
+        <table className="w-full min-w-[640px] border-collapse text-sm">
+          <thead>
+            <tr className="border-b border-white/10">
+              <SortableHeader label="Name" sortByKey="name" />
+              <SortableHeader label="Type" sortByKey="type" />
+              <SortableHeader label="Value" sortByKey="value" />
+              <th
+                scope="col"
+                className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-400"
+              >
+                Unit
+              </th>
+              <SortableHeader label="Share" sortByKey="share" />
+              <th
+                scope="col"
+                className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-400"
+              >
+                Coverage
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(({ node, value, share }) => {
+              const identity = getNodeIdentity(node);
+              const isSelected =
+                selectedNode !== null &&
+                (selectedNode.meta?.id ?? selectedNode.name) === identity;
+              const isSynthetic = node.meta?.synthetic === true;
+
+              return (
+                <tr
+                  key={identity}
+                  className={cn(
+                    "border-b border-white/5 last:border-0",
+                    isSelected && "bg-white/10",
+                    isSynthetic && "italic text-zinc-400",
+                  )}
+                >
+                  <th scope="row" className="p-0 text-left font-normal">
+                    <button
+                      type="button"
+                      onClick={() => onSelect(toSelectedNode(node, share))}
+                      className="flex w-full items-center gap-2 px-3 py-2 text-left text-zinc-200 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-stellar-light"
+                    >
+                      {node.name}
+                      {isSynthetic && (
+                        <Badge variant="secondary" className="text-[10px]">
+                          Remainder
+                        </Badge>
+                      )}
+                    </button>
+                  </th>
+                  <td className="px-3 py-2 text-zinc-400">{getNodeType(node)}</td>
+                  <td className="px-3 py-2 font-mono text-zinc-200">
+                    {formatExactNumber(value)}
+                  </td>
+                  <td className="px-3 py-2 text-zinc-500">{UNIT_LABEL}</td>
+                  <td className="px-3 py-2 text-zinc-300">{formatPercent(share)}</td>
+                  <td className="px-3 py-2 text-zinc-500">{getCoverageLabel(node)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/lib/entities/treemap-level.ts
+++ b/lib/entities/treemap-level.ts
@@ -1,0 +1,17 @@
+import type { TreemapNode } from "@/lib/types";
+
+export function getNodeValue(node: TreemapNode): number {
+  return node.value ?? node.meta?.opCount ?? 0;
+}
+
+export function resolveActiveLevel(
+  root: TreemapNode,
+  path: TreemapNode[],
+): { currentNode: TreemapNode; children: TreemapNode[]; levelTotal: number } {
+  const currentNode = path.length > 0 ? path[path.length - 1] : root;
+  const children = currentNode.children ?? [];
+  const childSum = children.reduce((sum, child) => sum + getNodeValue(child), 0);
+  const levelTotal = childSum > 0 ? childSum : getNodeValue(currentNode);
+
+  return { currentNode, children, levelTotal };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -310,6 +310,8 @@ export interface TreemapNodeMeta {
   eventType?: string;
   /** Coverage metadata for capped (top-N) treemap parents. */
   coverage?: TreemapCoverage;
+  /** Marks a synthetic aggregate (e.g. remainder) rather than a real entity. */
+  synthetic?: boolean;
 }
 
 export interface TreemapNode<TValue extends number | string = number> {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -41,3 +41,7 @@ export function truncateAddress(address: string, chars = 6): string {
   if (address.length <= chars * 2 + 3) return address;
   return `${address.slice(0, chars)}...${address.slice(-chars)}`;
 }
+
+export function formatExactNumber(value: number): string {
+  return value.toLocaleString("en-US");
+}


### PR DESCRIPTION
Closes #69

Ports TreemapDataTable (khyiengkc) onto current main after the fork head was wiped.

Keeps dashboard search focus APIs and lifts treemap drill path into DashboardProvider so the chart and table stay in sync.