### PR TITLE
Add fixture-data mode that runs without GCP credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ GOOGLE_APPLICATION_CREDENTIALS=./gcp-sa.json
 
 # Optional: max BigQuery bytes billed per query job (default: 1073741824 = 1 GB)
 # BIGQUERY_MAX_BYTES_BILLED=1073741824
+
+# Data source: live (default, requires GCP) or fixture (local non-live sample data).
+# Fixture mode is blocked in production (NODE_ENV/VERCEL_ENV=production).
+# LUMENMAP_DATA_SOURCE=fixture

--- a/app/api/activity/_handler.ts
+++ b/app/api/activity/_handler.ts
@@ -4,6 +4,7 @@ import { getActivityData } from "@/lib/hubble/activity";
 import { BigQueryLimitExceededError } from "@/lib/hubble/errors";
 import { hasBigQueryCredentials } from "@/lib/hubble/client";
 import { buildFixtureDataset } from "@/lib/hubble/fixture";
+import { resolveDataSource } from "@/lib/data-source";
 import { getFixtureActivityData } from "@/lib/fixtures/activity";
 import {
   classifyError,
@@ -129,12 +130,16 @@ export async function handleActivityRequest(
     period: parsed.period,
   });
 
-  // Fixture mode: explicit LUMENMAP_DATA_SOURCE=fixture (e2e) or missing GCP creds.
-  const forceFixture =
-    (process.env.LUMENMAP_DATA_SOURCE ?? "").trim().toLowerCase() === "fixture";
+  // Fixture mode is opt-in via LUMENMAP_DATA_SOURCE=fixture (blocked in production).
+  // Missing GCP credentials still serve fixtures in non-production for local DX.
+  const dataSource = resolveDataSource();
+  const forceFixture = dataSource === "fixture";
+  const allowMissingCredsFallback =
+    process.env.NODE_ENV !== "production" &&
+    process.env.VERCEL_ENV !== "production";
   if (
     fetchActivityData === getActivityData &&
-    (forceFixture || !hasBigQueryCredentials())
+    (forceFixture || (!hasBigQueryCredentials() && allowMissingCredsFallback))
   ) {
     const data = forceFixture
       ? getFixtureActivityData(parsed.period)

--- a/lib/data-source.test.ts
+++ b/lib/data-source.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { resolveDataSource } from "@/lib/data-source";
+
+function env(values: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  return values as NodeJS.ProcessEnv;
+}
+
+describe("resolveDataSource", () => {
+  it("defaults to live", () => {
+    assert.equal(resolveDataSource(env({})), "live");
+  });
+
+  it("accepts fixture outside production", () => {
+    assert.equal(
+      resolveDataSource(env({ LUMENMAP_DATA_SOURCE: "fixture", NODE_ENV: "test" })),
+      "fixture",
+    );
+  });
+
+  it("rejects fixture in production", () => {
+    assert.throws(
+      () =>
+        resolveDataSource(
+          env({
+            LUMENMAP_DATA_SOURCE: "fixture",
+            NODE_ENV: "production",
+          }),
+        ),
+      /not allowed in production/,
+    );
+  });
+});

--- a/lib/data-source.ts
+++ b/lib/data-source.ts
@@ -1,0 +1,36 @@
+export type DataSourceMode = "live" | "fixture";
+
+const FIXTURE_ENV = "LUMENMAP_DATA_SOURCE";
+
+/**
+ * Resolves the activity data source.
+ * Fixture mode is opt-in only and never allowed in production runtimes.
+ */
+export function resolveDataSource(
+  env: NodeJS.ProcessEnv = process.env,
+): DataSourceMode {
+  const raw = (env[FIXTURE_ENV] ?? "live").trim().toLowerCase();
+
+  if (raw === "fixture") {
+    if (env.NODE_ENV === "production" || env.VERCEL_ENV === "production") {
+      throw new Error(
+        `${FIXTURE_ENV}=fixture is not allowed in production. Fixture data is for local development and tests only.`,
+      );
+    }
+    return "fixture";
+  }
+
+  if (raw === "live" || raw === "" || raw === "hubble") {
+    return "live";
+  }
+
+  throw new Error(
+    `Unknown ${FIXTURE_ENV}="${env[FIXTURE_ENV]}". Use "live" (default) or "fixture".`,
+  );
+}
+
+export function isFixtureMode(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return resolveDataSource(env) === "fixture";
+}

--- a/lib/hubble/client.ts
+++ b/lib/hubble/client.ts
@@ -1,3 +1,4 @@
+import { resolveDataSource } from "@/lib/data-source";
 import { BigQuery } from "@google-cloud/bigquery";
 
 let client: BigQuery | null = null;
@@ -45,5 +46,5 @@ export function hasBigQueryCredentials(): boolean {
  * Playwright e2e suite and for local development without GCP credentials.
  */
 export function isFixtureMode(): boolean {
-  return process.env.LUMENMAP_DATA_SOURCE === "fixture";
+  return resolveDataSource() === "fixture";
 }


### PR DESCRIPTION
Completes fixture-data mode from closed PR #125 (Realbaji16): opt-in LUMENMAP_DATA_SOURCE=fixture with an explicit production runtime guard. Existing fixture datasets and e2e wiring on main are preserved.

Closes #89