### PR TITLE
Add fixture-data mode that runs without GCP credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ GOOGLE_APPLICATION_CREDENTIALS=./gcp-sa.json
 
 # Optional: max BigQuery bytes billed per query job (default: 1073741824 = 1 GB)
 # BIGQUERY_MAX_BYTES_BILLED=1073741824
+
+# Data source: live (default, requires GCP) or fixture (local non-live sample data).
+# Fixture mode is blocked in production (NODE_ENV/VERCEL_ENV=production).
+# LUMENMAP_DATA_SOURCE=fixture

--- a/README.md
+++ b/README.md
@@ -145,6 +145,20 @@ Dataset: `crypto-stellar.crypto_stellar_dbt`
 - Google Cloud project with BigQuery API enabled
 - Service account with BigQuery User role
 
+### Install and run (fixture mode, no GCP)
+
+Fixture mode serves checked-in, schema-validated activity sample data so you can run the dashboard without BigQuery credentials. **This is not live mainnet / Hubble data.**
+
+```bash
+cp .env.example .env.local
+# In .env.local:
+# LUMENMAP_DATA_SOURCE=fixture
+npm install
+npm run dev
+```
+
+Live mode still requires GCP credentials. Setting `LUMENMAP_DATA_SOURCE=fixture` in production (`NODE_ENV` or `VERCEL_ENV`) fails closed.
+
 ### Install and run
 
 ```bash
@@ -159,12 +173,11 @@ Set GCP credentials in `.env.local`, then open [http://localhost:3000](http://lo
 
 | Variable | Description |
 | --- | --- |
+| `LUMENMAP_DATA_SOURCE` | `live` (default) or `fixture`. Fixture is opt-in only and **blocked in production**. Non-live sample data for local onboarding and e2e. |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to service account JSON |
 | `GCP_SERVICE_ACCOUNT_KEY` | Base64-encoded service account JSON |
 
 | `CACHE_TTL_SECONDS` | Cache TTL in seconds. Default: 900 |
-| `LUMENMAP_DATA_SOURCE` | Set to `fixture` to serve deterministic local fixture data instead of querying BigQuery. No GCP credentials required. Used by the e2e suite. |
-
 | `CACHE_TTL_SECONDS` | Cache TTL in seconds. Supported range: 1–86,400. Default: 900 (invalid, negative, zero, or over-limit values fall back to default) |
 
 

--- a/app/api/activity/_handler.ts
+++ b/app/api/activity/_handler.ts
@@ -2,8 +2,7 @@ import { NextResponse } from "next/server";
 import { metrics } from "@/lib/telemetry/metrics";
 import { getActivityData } from "@/lib/hubble/activity";
 import { BigQueryLimitExceededError } from "@/lib/hubble/errors";
-import { hasBigQueryCredentials } from "@/lib/hubble/client";
-import { buildFixtureDataset } from "@/lib/hubble/fixture";
+import { resolveDataSource } from "@/lib/data-source";
 import { getFixtureActivityData } from "@/lib/fixtures/activity";
 import {
   classifyError,
@@ -129,18 +128,31 @@ export async function handleActivityRequest(
     period: parsed.period,
   });
 
-  // Fixture mode: explicit LUMENMAP_DATA_SOURCE=fixture (e2e) or missing GCP creds.
-  const forceFixture =
-    (process.env.LUMENMAP_DATA_SOURCE ?? "").trim().toLowerCase() === "fixture";
-  if (
-    fetchActivityData === getActivityData &&
-    (forceFixture || !hasBigQueryCredentials())
-  ) {
-    const data = forceFixture
-      ? getFixtureActivityData(parsed.period)
-      : buildFixtureDataset(parsed.period);
+  // Fixture mode is opt-in only (LUMENMAP_DATA_SOURCE=fixture) and blocked in production.
+  let dataSourceMode: "live" | "fixture" = "live";
+  try {
+    dataSourceMode = resolveDataSource();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logError({
+      event: "activity.request.error",
+      correlationId,
+      period: parsed.period,
+      durationMs: endTimer(timer),
+      errorClass: "validation",
+      errorMessage: message,
+    });
+    return NextResponse.json(
+      { code: "INVALID_DATA_SOURCE", message },
+      { status: 400 },
+    );
+  }
+
+  if (fetchActivityData === getActivityData && dataSourceMode === "fixture") {
+    const data = getFixtureActivityData(parsed.period);
     const validated = validateActivityResponse({
       ...toVisualizationResponse(data),
+      source: "fixture",
       fixture: true,
     });
     logInfo({

--- a/components/dashboard/FreshnessIndicator.tsx
+++ b/components/dashboard/FreshnessIndicator.tsx
@@ -51,6 +51,7 @@ export function FreshnessIndicator() {
     );
   }
 
+  const isFixture = data.source === "fixture" || data.fixture === true;
   const sourceTime = data.sourceTimestamp
     ? new Date(data.sourceTimestamp)
     : null;
@@ -60,6 +61,18 @@ export function FreshnessIndicator() {
     sourceTime && !Number.isNaN(sourceTime.getTime())
       ? formatLag(data.sourceTimestamp)
       : null;
+
+  if (isFixture) {
+    return (
+      <div className="flex flex-col gap-1">
+        <p className="text-xs text-amber-400/90">
+          Data source:{" "}
+          <span className="text-amber-300">Local fixture data</span>
+          {" · Deterministic data for local development and tests — not Hubble / mainnet"}
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-1">

--- a/lib/data-source.test.ts
+++ b/lib/data-source.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { isFixtureMode, resolveDataSource } from "@/lib/data-source";
+
+describe("resolveDataSource", () => {
+  it("defaults to live", () => {
+    assert.equal(resolveDataSource({}), "live");
+    assert.equal(resolveDataSource({ LUMENMAP_DATA_SOURCE: "live" }), "live");
+  });
+
+  it("accepts fixture outside production", () => {
+    assert.equal(
+      resolveDataSource({ LUMENMAP_DATA_SOURCE: "fixture", NODE_ENV: "development" }),
+      "fixture",
+    );
+    assert.equal(
+      isFixtureMode({ LUMENMAP_DATA_SOURCE: "fixture", NODE_ENV: "test" }),
+      true,
+    );
+  });
+
+  it("blocks fixture mode in production runtimes", () => {
+    assert.throws(
+      () =>
+        resolveDataSource({
+          LUMENMAP_DATA_SOURCE: "fixture",
+          NODE_ENV: "production",
+        }),
+      /not allowed in production/,
+    );
+    assert.throws(
+      () =>
+        resolveDataSource({
+          LUMENMAP_DATA_SOURCE: "fixture",
+          VERCEL_ENV: "production",
+        }),
+      /not allowed in production/,
+    );
+  });
+
+  it("rejects unknown values", () => {
+    assert.throws(
+      () => resolveDataSource({ LUMENMAP_DATA_SOURCE: "mock" }),
+      /Unknown LUMENMAP_DATA_SOURCE/,
+    );
+  });
+});

--- a/lib/data-source.ts
+++ b/lib/data-source.ts
@@ -1,0 +1,36 @@
+export type DataSourceMode = "live" | "fixture";
+
+const FIXTURE_ENV = "LUMENMAP_DATA_SOURCE";
+
+/**
+ * Resolves the activity data source.
+ * Fixture mode is opt-in only and never allowed in production runtimes.
+ */
+export function resolveDataSource(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
+): DataSourceMode {
+  const raw = (env[FIXTURE_ENV] ?? "live").trim().toLowerCase();
+
+  if (raw === "fixture") {
+    if (env.NODE_ENV === "production" || env.VERCEL_ENV === "production") {
+      throw new Error(
+        `${FIXTURE_ENV}=fixture is not allowed in production. Fixture data is for local development and tests only.`,
+      );
+    }
+    return "fixture";
+  }
+
+  if (raw === "live" || raw === "" || raw === "hubble") {
+    return "live";
+  }
+
+  throw new Error(
+    `Unknown ${FIXTURE_ENV}="${env[FIXTURE_ENV]}". Use "live" (default) or "fixture".`,
+  );
+}
+
+export function isFixtureMode(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
+): boolean {
+  return resolveDataSource(env) === "fixture";
+}

--- a/lib/fixtures/activity.ts
+++ b/lib/fixtures/activity.ts
@@ -21,7 +21,7 @@ export function getFixtureActivityData(period: Period): ActivityDataset {
     period,
     start: range.start.toISOString(),
     end: range.end.toISOString(),
-    source: "hubble",
+    source: "fixture",
     sourceTimestamp: range.end.toISOString(),
     isPeriodComplete: true,
     categories: raw.categories,

--- a/lib/hubble/fixture.ts
+++ b/lib/hubble/fixture.ts
@@ -1,7 +1,6 @@
 /**
- * Fixture data returned by /api/activity when BigQuery credentials are absent.
- * Used for front-end development and contributor onboarding without GCP access.
- * Values are illustrative; they do not reflect real network state.
+ * Illustrative fixture dataset for opt-in local/e2e mode (LUMENMAP_DATA_SOURCE=fixture).
+ * Values do not reflect real network state and must never be selected silently in production.
  */
 
 import { buildActivityMetricProvenance } from "@/lib/metrics/provenance";
@@ -12,7 +11,7 @@ export function buildFixtureDataset(period: Period = "1d"): ActivityDataset {
     period,
     start: "2026-01-01T00:00:00.000Z",
     end: "2026-01-01T23:59:59.999Z",
-    source: "hubble",
+    source: "fixture",
     sourceTimestamp: "2026-01-02T00:00:00.000Z",
     isPeriodComplete: true,
     categories: [

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,6 @@
 export type Period = "1d" | "7d" | "30d" | "month";
 
-export type DataSource = "hubble";
+export type DataSource = "hubble" | "fixture";
 
 /** Stable identifiers used by the public treemap contract. */
 export type MetricId =

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test lib/**/*.test.ts app/api/activity/route.test.ts",
+    "test": "tsx --test lib/*.test.ts lib/**/*.test.ts app/api/activity/route.test.ts",
     "protect:main": "node scripts/configure-main-protection.mjs",
     "sync:directory": "node scripts/sync-stellar-directory.mjs",
     "test:hubble": "node scripts/test-hubble-queries.mjs",
@@ -30,7 +30,8 @@
     "test:visual": "npx tsx scripts/test-visual-regression.mjs",
     "test:visual:update": "npx tsx scripts/test-visual-regression.mjs --update",
     "test:mappings": "npx tsx scripts/test-category-mappings.mjs",
-    "test:unit": "vitest run"
+    "test:unit": "vitest run",
+    "test:fixtures": "npx tsx scripts/verify-fixture-mode.ts"
   },
   "dependencies": {
     "@google-cloud/bigquery": "^8.3.1",

--- a/scripts/verify-fixture-mode.ts
+++ b/scripts/verify-fixture-mode.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { resolveDataSource } from "@/lib/data-source";
+import { getFixtureActivityData } from "@/lib/fixtures/activity";
+import { toVisualizationResponse } from "@/app/api/activity/_handler";
+import { validateActivityResponse } from "@/lib/schemas/validate-activity-response";
+
+function main() {
+  assert.equal(
+    resolveDataSource({
+      LUMENMAP_DATA_SOURCE: "fixture",
+      NODE_ENV: "development",
+    }),
+    "fixture",
+  );
+  assert.throws(() =>
+    resolveDataSource({
+      LUMENMAP_DATA_SOURCE: "fixture",
+      NODE_ENV: "production",
+    }),
+  );
+
+  const data = getFixtureActivityData("1d");
+  assert.equal(data.source, "fixture");
+  const validated = validateActivityResponse({
+    ...toVisualizationResponse(data),
+    source: "fixture",
+    fixture: true,
+  });
+  assert.equal(validated.fixture, true);
+  assert.ok(validated.treemaps.events);
+  console.log("verify-fixture-mode: OK");
+}
+
+main();


### PR DESCRIPTION
Closes #89

Ports opt-in fixture data mode (Realbaji16) onto current main after the fork head was wiped.

- `lib/data-source.ts` resolves `LUMENMAP_DATA_SOURCE` and blocks fixture mode in production
- Activity API uses fixtures only when explicitly opted in (no silent credential fallback)
- FreshnessIndicator shows **Local fixture data** for e2e/local fixture runs
- README/.env.example document non-live fixture onboarding
- `npm run test:fixtures` verifies the production guard and schema-validated fixture payload