### PR TITLE
Support browser zoom at 200% without content loss

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -105,6 +105,8 @@
 html,
 body {
   min-height: 100%;
+  /* Keep page scroll one-directional at high browser zoom / narrow widths */
+  overflow-x: hidden;
 }
 
 body {
@@ -117,4 +119,40 @@ button,
 input,
 textarea {
   font: inherit;
+}
+
+/* ─── Touch target utilities ─────────────────────────────────────────────────
+ *
+ * All interactive controls must present a minimum 44×44 CSS-pixel hit area
+ * as recommended by WCAG 2.5.5 (Target Size, AAA) and Apple / Google HIG.
+ *
+ * The .touch-target class can be applied to any element whose visual size
+ * is smaller than 44px. It expands the clickable area via a transparent
+ * pseudo-element overlay without altering layout or visual density.
+ *
+ * Usage:  <button class="touch-target …">…</button>
+ *
+ * Note: the Button component already enforces h-11 (44px) for all sizes so
+ * .touch-target is a supplementary escape hatch for custom interactive elements
+ * (e.g., bare <a> tags, SVG hit areas, third-party components).
+ * ─────────────────────────────────────────────────────────────────────────── */
+.touch-target {
+  position: relative;
+}
+
+.touch-target::after {
+  content: "";
+  position: absolute;
+  /* Expand hit area to at least 44×44px centered on the element */
+  inset: 50% auto auto 50%;
+  transform: translate(-50%, -50%);
+  min-width: 44px;
+  min-height: 44px;
+  width: 100%;
+  height: 100%;
+}
+
+/* Prevent accidental multi-touch zoom on interactive dashboard controls */
+.touch-manipulation {
+  touch-action: manipulation;
 }

--- a/components/dashboard/CategoryShareChart.tsx
+++ b/components/dashboard/CategoryShareChart.tsx
@@ -196,7 +196,7 @@ export function CategoryShareChart() {
             partial buckets marked on the axis
           </p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
           <Button
             size="sm"
             variant={mode === "percentage" ? "default" : "outline"}

--- a/components/dashboard/D3Treemap.tsx
+++ b/components/dashboard/D3Treemap.tsx
@@ -502,7 +502,7 @@ export function D3Treemap({ root, onSelect, path: pathProp, onPathChange }: D3Tr
 
       {tooltip ? (
         <div
-          className="pointer-events-none fixed z-50 flex max-w-[280px] flex-col gap-1.5 rounded-lg border border-zinc-800 bg-[#0B0E14]/95 p-3 text-sm shadow-xl backdrop-blur-md"
+          className="pointer-events-none fixed z-50 flex max-w-[min(280px,calc(100vw-1.5rem))] flex-col gap-1.5 rounded-lg border border-zinc-800 bg-[#0B0E14]/95 p-3 text-sm shadow-xl backdrop-blur-md"
           style={{ left: tooltip.x, top: tooltip.y }}
         >
           <div className="flex flex-col gap-0.5">

--- a/components/dashboard/DashboardPage.tsx
+++ b/components/dashboard/DashboardPage.tsx
@@ -18,9 +18,9 @@ function DashboardContent() {
   const { selectedNode } = useDashboard();
 
   return (
-    <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 overflow-x-hidden px-4 py-6 sm:px-6 lg:px-8">
-      <header className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-        <div className="space-y-3">
+    <div className="mx-auto flex w-full min-w-0 max-w-7xl flex-1 flex-col gap-6 overflow-x-hidden px-3 py-6 sm:px-6 lg:px-8">
+      <header className="flex min-w-0 flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="min-w-0 space-y-3">
           <div className="flex flex-wrap items-center gap-3">
             <Image
               src="/logo.png"
@@ -30,7 +30,7 @@ function DashboardContent() {
               className="shrink-0"
               priority
             />
-            <div>
+            <div className="min-w-0">
               <h1 className="text-2xl font-semibold tracking-tight text-white sm:text-3xl">
                 LumenMap
               </h1>
@@ -51,7 +51,9 @@ function DashboardContent() {
               {" · "}definitions on each KPI
             </p>
         </div>
-        <PeriodSelector />
+        <div className="min-w-0 shrink-0">
+          <PeriodSelector />
+        </div>
       </header>
 
       <FreshnessWarning />
@@ -62,10 +64,18 @@ function DashboardContent() {
 
       <CategoryShareChart />
 
-      <div className={`grid grid-cols-1 gap-6 transition-all duration-300 ${selectedNode ? "xl:grid-cols-[minmax(0,1fr)_320px]" : "xl:grid-cols-1"}`}>
-        <NetworkTreemap />
+      <div
+        className={`grid min-w-0 grid-cols-1 gap-6 transition-all duration-300 ${
+          selectedNode
+            ? "xl:grid-cols-[minmax(0,1fr)_minmax(0,20rem)]"
+            : "xl:grid-cols-1"
+        }`}
+      >
+        <div className="min-w-0">
+          <NetworkTreemap />
+        </div>
         {selectedNode && (
-          <div className="scroll-mt-4" id="detail-panel-container">
+          <div className="min-w-0 scroll-mt-4" id="detail-panel-container">
             <DetailPanel />
           </div>
         )}

--- a/components/dashboard/FreshnessWarning.tsx
+++ b/components/dashboard/FreshnessWarning.tsx
@@ -77,7 +77,7 @@ export function FreshnessWarning() {
           Data may be stale.
         </strong>{" "}
         Hubble has not refreshed within the expected window.{" "}
-        <span className="whitespace-nowrap font-mono text-xs text-amber-300/80">
+        <span className="break-words font-mono text-xs text-amber-300/80">
           Data through: {formatDataThrough(data.sourceTimestamp)} UTC
         </span>
       </span>

--- a/components/dashboard/NetworkTreemap.tsx
+++ b/components/dashboard/NetworkTreemap.tsx
@@ -166,15 +166,17 @@ export function NetworkTreemap() {
   return (
     <Card aria-busy={isLoading || undefined}>
       <CardHeader className="flex flex-col gap-4">
-        <div className="flex items-start justify-between gap-4">
-          <div>
+        <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0">
             <CardTitle>Network Treemap</CardTitle>
             <p className="text-xs text-zinc-500">
               Switch views to explore operation types or top accounts and
               contracts. Click legend items to filter categories.
             </p>
           </div>
-          <ExportControls />
+          <div className="min-w-0 shrink-0">
+            <ExportControls />
+          </div>
         </div>
         <TreemapViewSelector />
         <TreemapMetricSelector />

--- a/components/dashboard/TreemapDataTable.tsx
+++ b/components/dashboard/TreemapDataTable.tsx
@@ -163,7 +163,7 @@ export function TreemapDataTable({
         ({formatExactNumber(levelTotal)} {UNIT_LABEL} total)
       </p>
       <div className="overflow-x-auto rounded-xl border border-white/5 bg-black/20">
-        <table className="w-full min-w-[640px] border-collapse text-sm">
+        <table className="w-full min-w-[36rem] border-collapse text-sm">
           <thead>
             <tr className="border-b border-white/10">
               <SortableHeader


### PR DESCRIPTION
Audit dashboard layout at high browser zoom and keep controls, charts, and details usable without two-dimensional scrolling.

Restores `overflow-x: hidden` / touch utilities on the page canvas after the visual-token port, and softens fixed widths so header, export controls, category-share modes, detail panel, and tooltips reflow.

Closes #78