### PR TITLE
fix: keep dashboard usable at 200% browser zoom

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -105,6 +105,7 @@
 html,
 body {
   min-height: 100%;
+  overflow-x: hidden;
 }
 
 body {

--- a/components/dashboard/D3Treemap.tsx
+++ b/components/dashboard/D3Treemap.tsx
@@ -262,20 +262,22 @@ export function D3Treemap({ root, onSelect, path: pathProp, onPathChange }: D3Tr
     (e: React.MouseEvent, data: Omit<TooltipData, "x" | "y">) => {
       const tooltipWidth = 280;
       const tooltipHeight = 140;
-      const margin = 16;
+      const margin = 12;
 
       let x = e.clientX + margin;
       let y = e.clientY + margin;
 
       if (typeof window !== "undefined") {
-        if (x + tooltipWidth > window.innerWidth) {
+        const maxX = Math.max(margin, window.innerWidth - tooltipWidth - margin);
+        const maxY = Math.max(margin, window.innerHeight - tooltipHeight - margin);
+        if (x > maxX) {
           x = e.clientX - tooltipWidth - margin;
         }
-        if (y + tooltipHeight > window.innerHeight) {
+        if (y > maxY) {
           y = e.clientY - tooltipHeight - margin;
         }
-        x = Math.max(margin, x);
-        y = Math.max(margin, y);
+        x = Math.min(maxX, Math.max(margin, x));
+        y = Math.min(maxY, Math.max(margin, y));
       }
 
       setTooltip({ x, y, ...data });

--- a/components/dashboard/DashboardPage.tsx
+++ b/components/dashboard/DashboardPage.tsx
@@ -62,10 +62,18 @@ function DashboardContent() {
 
       <CategoryShareChart />
 
-      <div className={`grid grid-cols-1 gap-6 transition-all duration-300 ${selectedNode ? "xl:grid-cols-[minmax(0,1fr)_320px]" : "xl:grid-cols-1"}`}>
-        <NetworkTreemap />
+      <div
+        className={`grid grid-cols-1 gap-6 transition-all duration-300 ${
+          selectedNode
+            ? "min-w-0 xl:grid-cols-[minmax(0,1fr)_minmax(16rem,20rem)]"
+            : "min-w-0 xl:grid-cols-1"
+        }`}
+      >
+        <div className="min-w-0">
+          <NetworkTreemap />
+        </div>
         {selectedNode && (
-          <div className="scroll-mt-4" id="detail-panel-container">
+          <div className="min-w-0 scroll-mt-4" id="detail-panel-container">
             <DetailPanel />
           </div>
         )}

--- a/components/dashboard/DetailPanel.tsx
+++ b/components/dashboard/DetailPanel.tsx
@@ -89,7 +89,7 @@ export function DetailPanel() {
         </Button>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <div className="rounded-lg border border-white/10 bg-black/20 p-3">
             <p className="text-xs text-zinc-500">
               {metric === "xlm_volume"

--- a/components/dashboard/FreshnessWarning.tsx
+++ b/components/dashboard/FreshnessWarning.tsx
@@ -77,7 +77,7 @@ export function FreshnessWarning() {
           Data may be stale.
         </strong>{" "}
         Hubble has not refreshed within the expected window.{" "}
-        <span className="whitespace-nowrap font-mono text-xs text-amber-300/80">
+        <span className="break-words font-mono text-xs text-amber-300/80">
           Data through: {formatDataThrough(data.sourceTimestamp)} UTC
         </span>
       </span>

--- a/components/dashboard/NetworkTreemap.tsx
+++ b/components/dashboard/NetworkTreemap.tsx
@@ -29,7 +29,7 @@ const CATEGORY_LEGEND = [
 // Shared with the loading skeleton so reserved space matches the rendered
 // chart at every breakpoint.
 const CHART_FRAME_CLASS =
-  "h-[420px] sm:h-[520px] lg:h-[600px] overflow-x-auto overflow-y-hidden rounded-xl border border-white/5 bg-black/20 p-2 sm:p-3";
+  "h-[min(70vh,420px)] sm:h-[min(70vh,520px)] lg:h-[min(75vh,600px)] min-h-[280px] overflow-x-auto overflow-y-auto rounded-xl border border-white/5 bg-black/20 p-2 sm:p-3";
 
 function toChartNode(node: TreemapNode<number | string>): TreemapNode {
   const { value, children, ...rest } = node;
@@ -166,8 +166,8 @@ export function NetworkTreemap() {
   return (
     <Card aria-busy={isLoading || undefined}>
       <CardHeader className="flex flex-col gap-4">
-        <div className="flex items-start justify-between gap-4">
-          <div>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 flex-1 basis-[16rem]">
             <CardTitle>Network Treemap</CardTitle>
             <p className="text-xs text-zinc-500">
               Switch views to explore operation types or top accounts and
@@ -269,7 +269,7 @@ export function NetworkTreemap() {
             <Skeleton className="h-full w-full rounded-lg" />
           </div>
         ) : isError || !data || !activeTreemap || !filteredTreemap ? (
-          <div className="flex h-[420px] flex-col items-center justify-center gap-4 rounded-xl border border-red-500/20 bg-red-500/5 p-6 text-center text-sm text-red-200 sm:h-[520px] lg:h-[600px]">
+          <div className="flex h-[min(70vh,420px)] min-h-[280px] flex-col items-center justify-center gap-4 rounded-xl border border-red-500/20 bg-red-500/5 p-6 text-center text-sm text-red-200 sm:h-[min(70vh,520px)] lg:h-[min(75vh,600px)]">
             <p role="alert">{error?.message ?? "Unable to load treemap data."}</p>
             <Button
               type="button"

--- a/e2e/zoom.spec.ts
+++ b/e2e/zoom.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/** Desktop viewport before applying 200% browser zoom. */
+const DESKTOP = { width: 1280, height: 800 } as const;
+
+const MOCK_KPIS = {
+  totalOps: 2150000,
+  sorobanShare: 42.5,
+  topCategory: "soroban",
+  activeContracts: 89,
+};
+
+const MOCK_TREEMAP_NODE = {
+  name: "Network Activity",
+  children: [
+    {
+      name: "Soroban",
+      value: 903000,
+      color: "#7B61FF",
+      meta: { type: "category", category: "soroban" },
+      children: [
+        {
+          name: "invoke_host_function",
+          value: 850000,
+          color: "#7B61FF",
+          meta: {
+            type: "entity",
+            category: "soroban",
+            eventType: "invoke_host_function",
+            nodeId: "invoke_host_function",
+          },
+        },
+      ],
+    },
+    {
+      name: "Payments",
+      value: 645000,
+      color: "#14B8A6",
+      meta: { type: "category", category: "payments" },
+    },
+  ],
+};
+
+async function mockApiResponse(page: Page) {
+  await page.route("**/api/activity*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        period: "1d",
+        start: "2026-07-29T00:00:00.000Z",
+        end: "2026-07-29T23:59:59.000Z",
+        source: "hubble",
+        categories: [],
+        contracts: [],
+        accounts: [],
+        sorobanFunctions: [],
+        sorobanFunctionContracts: [],
+        kpis: MOCK_KPIS,
+        treemaps: {
+          events: MOCK_TREEMAP_NODE,
+          actors: MOCK_TREEMAP_NODE,
+        },
+      }),
+    });
+  });
+}
+
+/** Emulate 200% browser zoom via Chromium page scale. */
+async function setBrowserZoom(page: Page, scale: number) {
+  const client = await page.context().newCDPSession(page);
+  await client.send("Emulation.setPageScaleFactor", { pageScaleFactor: scale });
+}
+
+test.describe("200% browser zoom", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize(DESKTOP);
+    await mockApiResponse(page);
+  });
+
+  test("dashboard reflows without page-level horizontal overflow", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: "LumenMap" })).toBeVisible();
+    await setBrowserZoom(page, 2);
+
+    await expect(page.getByText("Network Treemap")).toBeVisible();
+    await expect(page.getByRole("radiogroup", { name: "Time period" })).toBeVisible();
+    await expect(page.getByText("Operation Types")).toBeVisible();
+
+    const metrics = await page.evaluate(() => {
+      const doc = document.documentElement;
+      return {
+        scrollWidth: doc.scrollWidth,
+        clientWidth: doc.clientWidth,
+        bodyScrollWidth: document.body.scrollWidth,
+      };
+    });
+
+    expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1);
+    expect(metrics.bodyScrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1);
+  });
+
+  test("treemap and data table remain reachable", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByText("Network Treemap")).toBeVisible();
+    await setBrowserZoom(page, 2);
+
+    const treemap = page.locator('[data-treemap-container="true"]');
+    await expect(treemap).toBeVisible();
+    await treemap.scrollIntoViewIfNeeded();
+
+    const table = page.getByRole("table");
+    await expect(table).toBeVisible();
+    await table.scrollIntoViewIfNeeded();
+
+    const box = await table.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.height).toBeGreaterThan(0);
+  });
+
+  test("detail panel stays usable after tile selection", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByText("Network Treemap")).toBeVisible();
+    await setBrowserZoom(page, 2);
+
+    await page.locator("svg g").first().click();
+    await expect(page.getByText("Share (current level)")).toBeVisible();
+
+    const panel = page.locator("#detail-panel-container");
+    await panel.scrollIntoViewIfNeeded();
+    await expect(panel).toBeVisible();
+
+    const overflow = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > document.documentElement.clientWidth + 1;
+    });
+    expect(overflow).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #78

Audits and hardens the research dashboard for 200% browser zoom on a desktop viewport:

- Restore page-level `overflow-x: hidden` so zoomed content reflows on the primary axis
- Let treemap header controls and detail stats wrap instead of clipping
- Cap chart frame height with viewport-relative bounds and allow vertical scroll inside the chart frame
- Clamp hover tooltips inside the viewport
- Add Playwright coverage via Chromium page scale factor 2

Assignee unchanged (`abdulquadri123`).