### PR TITLE
feat: persist metric, period, and treemap path in the URL

### DIFF
--- a/components/dashboard/DashboardProvider.tsx
+++ b/components/dashboard/DashboardProvider.tsx
@@ -5,10 +5,17 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import type { TreemapViewId } from "@/lib/constants";
+import {
+  parseDashboardUrlSearch,
+  resolveDrillPath,
+  writeDashboardUrlSearch,
+} from "@/lib/dashboard-url-state";
 import { findTreemapPath, type SearchResult } from "@/lib/search";
 import type {
   ActivityVisualizationResponse,
@@ -101,6 +108,23 @@ function selectedNodeFromSearch(
   return searchResultToSelectedNode(result);
 }
 
+function activeTreemapRoot(
+  data: ActivityVisualizationResponse | undefined,
+  treemapView: TreemapViewId,
+  metric: DashboardMetricId,
+): TreemapNode | null {
+  if (!data) return null;
+  const payload =
+    metric === "xlm_volume"
+      ? data.treemaps[`xlm_${treemapView}` as keyof typeof data.treemaps]
+      : metric === "usdc"
+        ? data.treemaps[`usdc_${treemapView}` as keyof typeof data.treemaps]
+        : metric === "transactions"
+          ? data.treemaps[`txn_${treemapView}` as keyof typeof data.treemaps]
+          : data.treemaps[treemapView];
+  return (payload as TreemapNode | undefined) ?? null;
+}
+
 export function DashboardProvider({ children }: { children: React.ReactNode }) {
   const [period, setPeriodState] = useState<Period>("1d");
   const [treemapView, setTreemapViewState] = useState<TreemapViewId>("events");
@@ -108,11 +132,26 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
   const [activeLevelPath, setActiveLevelPath] = useState<TreemapNode[]>([]);
   const [focusRequest, setFocusRequest] = useState<SearchResult | null>(null);
+  const pendingPathSegments = useRef<string[] | null>(null);
+  const [urlReady, setUrlReady] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const parsed = parseDashboardUrlSearch(window.location.search);
+    if (parsed.period) setPeriodState(parsed.period);
+    if (parsed.metric) setMetricState(parsed.metric);
+    if (parsed.view) setTreemapViewState(parsed.view);
+    if (parsed.pathSegments && parsed.pathSegments.length > 0) {
+      pendingPathSegments.current = parsed.pathSegments;
+    }
+    setUrlReady(true);
+  }, []);
 
   const handleSetPeriod = useCallback((newPeriod: Period) => {
     setSelectedNode(null);
     setActiveLevelPath([]);
     setFocusRequest(null);
+    pendingPathSegments.current = null;
     setPeriodState(newPeriod);
   }, []);
 
@@ -120,6 +159,7 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
     setSelectedNode(null);
     setActiveLevelPath([]);
     setFocusRequest(null);
+    pendingPathSegments.current = null;
     setTreemapViewState(newView);
   }, []);
 
@@ -127,6 +167,7 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
     setSelectedNode(null);
     setActiveLevelPath([]);
     setFocusRequest(null);
+    pendingPathSegments.current = null;
     setMetricState(newMetric);
   }, []);
 
@@ -135,6 +176,34 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
     queryFn: () => fetchActivity(period),
     staleTime: 60_000,
   });
+
+  useEffect(() => {
+    const segments = pendingPathSegments.current;
+    if (!segments || segments.length === 0 || !query.data) return;
+    const root = activeTreemapRoot(query.data, treemapView, metric);
+    if (!root) return;
+    const resolved = resolveDrillPath(root, segments);
+    pendingPathSegments.current = null;
+    setActiveLevelPath(resolved);
+  }, [query.data, treemapView, metric]);
+
+  useEffect(() => {
+    if (!urlReady || typeof window === "undefined") return;
+    const next = writeDashboardUrlSearch({
+      period,
+      metric,
+      view: treemapView,
+      path: activeLevelPath,
+      currentSearch: window.location.search,
+    });
+    if (next !== window.location.search) {
+      window.history.replaceState(
+        window.history.state,
+        "",
+        `${window.location.pathname}${next}`,
+      );
+    }
+  }, [urlReady, period, metric, treemapView, activeLevelPath]);
 
   const selectSearchResult = useCallback(
     (result: SearchResult) => {
@@ -200,4 +269,3 @@ export function useDashboard() {
   }
   return context;
 }
-

--- a/components/dashboard/DashboardProvider.tsx
+++ b/components/dashboard/DashboardProvider.tsx
@@ -138,13 +138,16 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (typeof window === "undefined") return;
     const parsed = parseDashboardUrlSearch(window.location.search);
-    if (parsed.period) setPeriodState(parsed.period);
-    if (parsed.metric) setMetricState(parsed.metric);
-    if (parsed.view) setTreemapViewState(parsed.view);
     if (parsed.pathSegments && parsed.pathSegments.length > 0) {
       pendingPathSegments.current = parsed.pathSegments;
     }
-    setUrlReady(true);
+    // Defer state updates so hydration does not cascade synchronously in the effect body.
+    queueMicrotask(() => {
+      if (parsed.period) setPeriodState(parsed.period);
+      if (parsed.metric) setMetricState(parsed.metric);
+      if (parsed.view) setTreemapViewState(parsed.view);
+      setUrlReady(true);
+    });
   }, []);
 
   const handleSetPeriod = useCallback((newPeriod: Period) => {

--- a/lib/dashboard-url-state.test.ts
+++ b/lib/dashboard-url-state.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { TreemapNode } from "@/lib/types";
+import {
+  decodeDrillPathParam,
+  encodeDrillPath,
+  isValidMetric,
+  parseDashboardUrlSearch,
+  resolveDrillPath,
+  writeDashboardUrlSearch,
+} from "./dashboard-url-state";
+
+const sampleRoot: TreemapNode = {
+  name: "Network Activity",
+  children: [
+    {
+      id: "soroban",
+      name: "Soroban",
+      value: 100,
+      children: [
+        {
+          id: "invoke_host_function",
+          name: "invoke_host_function",
+          value: 80,
+        },
+      ],
+    },
+    {
+      name: "Payments",
+      value: 50,
+    },
+  ],
+};
+
+describe("dashboard URL state", () => {
+  it("validates known metrics only", () => {
+    assert.equal(isValidMetric("ops"), true);
+    assert.equal(isValidMetric("usdc"), true);
+    assert.equal(isValidMetric("tvl"), false);
+    assert.equal(isValidMetric(null), false);
+  });
+
+  it("parses period and metric from search params", () => {
+    const parsed = parseDashboardUrlSearch("?period=7d&metric=xlm_volume&view=actors");
+    assert.equal(parsed.period, "7d");
+    assert.equal(parsed.metric, "xlm_volume");
+    assert.equal(parsed.view, "actors");
+  });
+
+  it("ignores invalid period and metric values", () => {
+    const parsed = parseDashboardUrlSearch("?period=90d&metric=nope");
+    assert.equal(parsed.period, undefined);
+    assert.equal(parsed.metric, undefined);
+  });
+
+  it("encodes and restores drill path segments", () => {
+    const path = resolveDrillPath(sampleRoot, ["soroban", "invoke_host_function"]);
+    assert.equal(path.length, 2);
+    assert.equal(path[1].name, "invoke_host_function");
+
+    const encoded = encodeDrillPath(path);
+    assert.equal(encoded, "soroban/invoke_host_function");
+    assert.deepEqual(decodeDrillPathParam(encoded), [
+      "soroban",
+      "invoke_host_function",
+    ]);
+  });
+
+  it("stops restoring at the first missing path segment", () => {
+    const path = resolveDrillPath(sampleRoot, ["soroban", "missing"]);
+    assert.equal(path.length, 1);
+    assert.equal(path[0].name, "Soroban");
+  });
+
+  it("writes period, metric, view, and path into the query string", () => {
+    const path = resolveDrillPath(sampleRoot, ["Payments"]);
+    const search = writeDashboardUrlSearch({
+      period: "30d",
+      metric: "transactions",
+      view: "events",
+      path,
+      currentSearch: "?utm=keep",
+    });
+    assert.match(search, /period=30d/);
+    assert.match(search, /metric=transactions/);
+    assert.match(search, /view=events/);
+    assert.match(search, /path=Payments/);
+    assert.match(search, /utm=keep/);
+  });
+});

--- a/lib/dashboard-url-state.ts
+++ b/lib/dashboard-url-state.ts
@@ -1,0 +1,121 @@
+import { isValidPeriod } from "@/lib/periods";
+import type { DashboardMetricId, Period, TreemapNode } from "@/lib/types";
+import type { TreemapViewId } from "@/lib/constants";
+import { TREEMAP_VIEWS } from "@/lib/constants";
+
+const METRIC_IDS: DashboardMetricId[] = [
+  "ops",
+  "xlm_volume",
+  "usdc",
+  "transactions",
+];
+
+export function isValidMetric(
+  value: string | null | undefined,
+): value is DashboardMetricId {
+  return !!value && METRIC_IDS.includes(value as DashboardMetricId);
+}
+
+export function isValidTreemapView(
+  value: string | null | undefined,
+): value is TreemapViewId {
+  return TREEMAP_VIEWS.some((view) => view.id === value);
+}
+
+/** Stable path segment for a treemap node (prefer id, fall back to name). */
+export function treemapPathSegment(node: TreemapNode): string {
+  return String(node.id ?? node.name);
+}
+
+export function encodeDrillPath(path: TreemapNode[]): string | null {
+  if (path.length === 0) return null;
+  return path.map((node) => encodeURIComponent(treemapPathSegment(node))).join("/");
+}
+
+export function decodeDrillPathParam(value: string | null): string[] {
+  if (!value) return [];
+  return value
+    .split("/")
+    .map((segment) => {
+      try {
+        return decodeURIComponent(segment);
+      } catch {
+        return segment;
+      }
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Walk the treemap using encoded path segments. Stops at the first missing
+ * child so stale share links restore the deepest still-valid level.
+ */
+export function resolveDrillPath(
+  root: TreemapNode,
+  segments: string[],
+): TreemapNode[] {
+  const resolved: TreemapNode[] = [];
+  let current = root;
+
+  for (const segment of segments) {
+    const child = current.children?.find(
+      (node) => treemapPathSegment(node) === segment || node.name === segment,
+    );
+    if (!child) break;
+    resolved.push(child);
+    current = child;
+  }
+
+  return resolved;
+}
+
+export type DashboardUrlState = {
+  period: Period;
+  metric: DashboardMetricId;
+  view?: TreemapViewId;
+  pathSegments: string[];
+};
+
+export function parseDashboardUrlSearch(
+  search: string,
+): Partial<DashboardUrlState> {
+  const params = new URLSearchParams(
+    search.startsWith("?") ? search.slice(1) : search,
+  );
+  const next: Partial<DashboardUrlState> = {
+    pathSegments: decodeDrillPathParam(params.get("path")),
+  };
+
+  const period = params.get("period");
+  if (isValidPeriod(period)) next.period = period;
+
+  const metric = params.get("metric");
+  if (isValidMetric(metric)) next.metric = metric;
+
+  const view = params.get("view");
+  if (isValidTreemapView(view)) next.view = view;
+
+  return next;
+}
+
+export function writeDashboardUrlSearch(input: {
+  period: Period;
+  metric: DashboardMetricId;
+  view: TreemapViewId;
+  path: TreemapNode[];
+  currentSearch?: string;
+}): string {
+  const params = new URLSearchParams(
+    (input.currentSearch ?? "").replace(/^\?/, ""),
+  );
+  params.set("period", input.period);
+  params.set("metric", input.metric);
+  params.set("view", input.view);
+
+  const encodedPath = encodeDrillPath(input.path);
+  if (encodedPath) params.set("path", encodedPath);
+  else params.delete("path");
+
+  const query = params.toString();
+  return query ? `?${query}` : "";
+}


### PR DESCRIPTION
Closes #47
Closes #48

Recovers URL-state work after the Elvis fork heads were wiped:

- Encode `period`, `metric`, and hierarchy `view` in the query string
- Encode the active treemap drill path with stable node segments
- Initialize from valid params and fall back safely for invalid/stale values
- Update the URL with `history.replaceState` (no full reload)

Assignee unchanged (`Dev-ElvisTobi`).