### PR TITLE
feat: add protocol TVL metric backed by adapter snapshots

### DIFF
--- a/app/api/activity/route.test.ts
+++ b/app/api/activity/route.test.ts
@@ -119,6 +119,16 @@ function mockActivityDataset(period: Period): ActivityDataset {
           },
         },
       },
+      protocol_tvl: {
+        name: "Protocol TVL",
+        metric: "tvl",
+        value: "0",
+        unit: {
+          kind: "asset",
+          asset: { type: "issued", code: "USD", issuer: "adapter" },
+        },
+        children: [],
+      },
     },
     metricProvenance: buildActivityMetricProvenance(),
   };

--- a/components/dashboard/DashboardProvider.tsx
+++ b/components/dashboard/DashboardProvider.tsx
@@ -115,13 +115,15 @@ function activeTreemapRoot(
 ): TreemapNode | null {
   if (!data) return null;
   const payload =
-    metric === "xlm_volume"
-      ? data.treemaps[`xlm_${treemapView}` as keyof typeof data.treemaps]
-      : metric === "usdc"
-        ? data.treemaps[`usdc_${treemapView}` as keyof typeof data.treemaps]
-        : metric === "transactions"
-          ? data.treemaps[`txn_${treemapView}` as keyof typeof data.treemaps]
-          : data.treemaps[treemapView];
+    metric === "protocol_tvl"
+      ? data.treemaps.protocol_tvl
+      : metric === "xlm_volume"
+        ? data.treemaps[`xlm_${treemapView}` as keyof typeof data.treemaps]
+        : metric === "usdc"
+          ? data.treemaps[`usdc_${treemapView}` as keyof typeof data.treemaps]
+          : metric === "transactions"
+            ? data.treemaps[`txn_${treemapView}` as keyof typeof data.treemaps]
+            : data.treemaps[treemapView];
   return (payload as TreemapNode | undefined) ?? null;
 }
 

--- a/components/dashboard/DetailPanel.tsx
+++ b/components/dashboard/DetailPanel.tsx
@@ -98,10 +98,14 @@ export function DetailPanel() {
                   ? "USDC volume"
                   : metric === "transactions"
                     ? "Transaction count"
-                    : "Activity count"}
+                    : metric === "protocol_tvl"
+                      ? "TVL (USD)"
+                      : "Activity count"}
             </p>
             <p className="text-lg font-semibold text-white">
-              {formatNumber(selectedNode.value)}
+              {metric === "protocol_tvl"
+                ? `$${formatNumber(selectedNode.meta?.tvlUsd ?? selectedNode.value)}`
+                : formatNumber(selectedNode.value)}
             </p>
           </div>
           <div className="rounded-lg border border-white/10 bg-black/20 p-3">
@@ -111,6 +115,20 @@ export function DetailPanel() {
             </p>
           </div>
         </div>
+
+        {selectedNode.meta?.adapterStatusLabel ? (
+          <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+            <p className="mb-1 text-xs text-zinc-500">Adapter status</p>
+            <p className="text-sm text-zinc-200">
+              {selectedNode.meta.adapterStatusLabel}
+            </p>
+            {selectedNode.meta.snapshotTime ? (
+              <p className="mt-1 font-mono text-xs text-zinc-500">
+                Snapshot: {selectedNode.meta.snapshotTime}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
 
         {selectedNode.meta?.protocol ? (
           <div>

--- a/components/dashboard/NetworkTreemap.test.tsx
+++ b/components/dashboard/NetworkTreemap.test.tsx
@@ -56,6 +56,12 @@ vi.mock("@/components/dashboard/DashboardProvider", () => ({
           unit: "USDC",
           children: [],
         },
+        protocol_tvl: {
+          name: "Protocol TVL",
+          metric: "tvl",
+          unit: "USD",
+          children: [],
+        },
       },
       kpis: {
         totalOps: { kind: "operations", unit: "ops", value: 123 },

--- a/components/dashboard/NetworkTreemap.tsx
+++ b/components/dashboard/NetworkTreemap.tsx
@@ -126,7 +126,9 @@ export function NetworkTreemap() {
   };
 
   const activePayload = data
-    ? metric === "xlm_volume"
+    ? metric === "protocol_tvl"
+      ? data.treemaps.protocol_tvl
+      : metric === "xlm_volume"
       ? data.treemaps[`xlm_${treemapView}` as keyof typeof data.treemaps]
       : metric === "usdc"
         ? data.treemaps[`usdc_${treemapView}` as keyof typeof data.treemaps]
@@ -140,8 +142,9 @@ export function NetworkTreemap() {
     (!activeTreemap.children || activeTreemap.children.length === 0);
   const filteredTreemap = useMemo(() => {
     if (!activeTreemap) return null;
+    if (metric === "protocol_tvl") return activeTreemap;
     return filterTreemapByCategories(activeTreemap, excludedCategories);
-  }, [activeTreemap, excludedCategories]);
+  }, [activeTreemap, excludedCategories, metric]);
 
   const filterAnnouncement =
     excludedCategories.size === 0
@@ -161,7 +164,9 @@ export function NetworkTreemap() {
         ? "USDC payment volume"
         : metric === "transactions"
           ? "transactions"
-          : "operations";
+          : metric === "protocol_tvl"
+            ? "protocol TVL"
+            : "operations";
 
   return (
     <Card aria-busy={isLoading || undefined}>
@@ -180,6 +185,7 @@ export function NetworkTreemap() {
         </div>
         <TreemapViewSelector />
         <TreemapMetricSelector />
+        {metric !== "protocol_tvl" ? (
         <div className="flex flex-wrap gap-2">
           {/* Inject pattern defs so legend swatches can reference them */}
           <svg width="0" height="0" aria-hidden="true" style={{ position: "absolute" }}>
@@ -260,6 +266,11 @@ export function NetworkTreemap() {
             </Button>
           ) : null}
         </div>
+        ) : (
+          <p className="text-xs text-zinc-500">
+            Tile colors encode adapter status: complete, partial, or stale.
+          </p>
+        )}
         <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
           {filterAnnouncement}
         </div>

--- a/components/dashboard/TreemapMetricSelector.tsx
+++ b/components/dashboard/TreemapMetricSelector.tsx
@@ -18,7 +18,9 @@ export function TreemapMetricSelector() {
         ? "Tile size is proportional to XLM payment volume. Other operation types are hidden."
         : metric === "usdc"
           ? "Tile size is proportional to verified USDC payment volume. Unsupported same-code assets are excluded."
-          : "Tile size is proportional to the number of transactions.";
+          : metric === "protocol_tvl"
+            ? "Tile size is proportional to adapter-backed protocol TVL in USD. Partial and stale adapters stay visible."
+            : "Tile size is proportional to the number of transactions.";
 
   return (
     <div className="flex flex-col gap-2 sm:gap-3">
@@ -57,6 +59,14 @@ export function TreemapMetricSelector() {
           }
         >
           Transaction Count
+        </Button>
+        <Button
+          variant={metric === "protocol_tvl" ? "default" : "outline"}
+          size="sm"
+          onClick={() => setMetric("protocol_tvl")}
+          title="Size tiles by adapter-backed protocol TVL in USD"
+        >
+          Protocol TVL
         </Button>
       </div>
       <p className="text-xs text-zinc-500">{description}</p>

--- a/lib/dashboard-url-state.test.ts
+++ b/lib/dashboard-url-state.test.ts
@@ -36,6 +36,7 @@ describe("dashboard URL state", () => {
   it("validates known metrics only", () => {
     assert.equal(isValidMetric("ops"), true);
     assert.equal(isValidMetric("usdc"), true);
+    assert.equal(isValidMetric("protocol_tvl"), true);
     assert.equal(isValidMetric("tvl"), false);
     assert.equal(isValidMetric(null), false);
   });

--- a/lib/dashboard-url-state.ts
+++ b/lib/dashboard-url-state.ts
@@ -8,6 +8,7 @@ const METRIC_IDS: DashboardMetricId[] = [
   "xlm_volume",
   "usdc",
   "transactions",
+  "protocol_tvl",
 ];
 
 export function isValidMetric(

--- a/lib/entities/build-treemap.ts
+++ b/lib/entities/build-treemap.ts
@@ -31,6 +31,8 @@ import {
   USDC_ASSET_UNIT,
   XLM_ASSET_UNIT,
 } from "@/lib/types";
+import { buildProtocolTvlTreemap } from "@/lib/tvl/build-protocol-treemap";
+import { PROTOCOL_TVL_FIXTURE_RESULTS } from "@/lib/tvl/protocol-registry";
 
 type BuildMetricId = "ops" | "xlm_volume";
 
@@ -779,6 +781,7 @@ export function buildAllTreemaps(input: BuildTreemapInput): ActivityTreemaps {
       metric: "asset_volume",
       unit: USDC_ASSET_UNIT,
     },
+    protocol_tvl: buildProtocolTvlTreemap(PROTOCOL_TVL_FIXTURE_RESULTS),
   };
 }
 

--- a/lib/hubble/fixture.ts
+++ b/lib/hubble/fixture.ts
@@ -306,6 +306,17 @@ export function buildFixtureDataset(period: Period = "1d"): ActivityDataset {
           },
         },
       },
+      protocol_tvl: {
+        name: "Protocol TVL",
+        metric: "tvl",
+        value: "740000000",
+        unit: {
+          kind: "asset",
+          asset: { type: "issued", code: "USD", issuer: "adapter" },
+        },
+        meta: { type: "root", tvlUsd: 740000000, childCount: 0 },
+        children: [],
+      },
     },
     metricProvenance: buildActivityMetricProvenance(),
   };

--- a/lib/metrics/units.ts
+++ b/lib/metrics/units.ts
@@ -36,6 +36,12 @@ const METRIC_UNITS: Record<string, MetricUnitInfo> = {
     unitSuffix: "USDC",
     unitLabel: "USDC",
   },
+  protocol_tvl: {
+    id: "protocol_tvl",
+    label: "Protocol TVL",
+    unitSuffix: "USD",
+    unitLabel: "USD",
+  },
 };
 
 export function getMetricUnit(metric: DashboardMetricId): MetricUnitInfo {

--- a/lib/schemas/activity-response.ts
+++ b/lib/schemas/activity-response.ts
@@ -66,6 +66,7 @@ export const treemapNodeTypeSchema = z.enum([
   "entity",
   "contract",
   "account",
+  "protocol",
 ]);
 
 export const treemapNodeMetaSchema = z.object({
@@ -78,6 +79,10 @@ export const treemapNodeMetaSchema = z.object({
   txnCount: finiteNumberSchema.optional(),
   xlmVolume: finiteNumberSchema.optional(),
   usdcVolume: finiteNumberSchema.optional(),
+  tvlUsd: finiteNumberSchema.optional(),
+  snapshotTime: z.string().optional(),
+  adapterStatus: z.string().optional(),
+  adapterStatusLabel: z.string().optional(),
   childCount: finiteNumberSchema.optional(),
   eventType: z.string().optional(),
 });
@@ -169,6 +174,14 @@ export const assetVolumeTreemapSchema = z.intersection(
   assetTreemapNodeSchema,
   z.object({
     metric: z.literal("asset_volume"),
+    unit: assetUnitSchema,
+  }),
+);
+
+export const tvlTreemapSchema = z.intersection(
+  assetTreemapNodeSchema,
+  z.object({
+    metric: z.literal("tvl"),
     unit: assetUnitSchema,
   }),
 );
@@ -330,6 +343,7 @@ export const activityResponseSchema = z.object({
     xlm_actors: assetVolumeTreemapSchema,
     usdc_events: assetVolumeTreemapSchema,
     usdc_actors: assetVolumeTreemapSchema,
+    protocol_tvl: tvlTreemapSchema,
   }),
   metricProvenance: activityMetricProvenanceSchema,
   protocols: protocolSummarySchema.optional(),

--- a/lib/schemas/fixtures/valid-activity-response.ts
+++ b/lib/schemas/fixtures/valid-activity-response.ts
@@ -286,6 +286,17 @@ export const validActivityResponseFixture: ActivityResponse = {
       meta: { type: "root", usdcVolume: 100.5 },
       children: [],
     },
+    protocol_tvl: {
+      name: "Protocol TVL",
+      metric: "tvl",
+      unit: {
+        kind: "asset",
+        asset: { type: "issued", code: "USD", issuer: "adapter" },
+      },
+      value: "100",
+      meta: { type: "root", tvlUsd: 100, childCount: 0 },
+      children: [],
+    },
   },
   metricProvenance: buildActivityMetricProvenance(),
 };

--- a/lib/tvl/build-protocol-treemap.test.ts
+++ b/lib/tvl/build-protocol-treemap.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildProtocolTvlTreemap } from "./build-protocol-treemap";
+import { fetchProtocolTvlResults } from "./protocol-registry";
+
+describe("protocol TVL treemap", () => {
+  it("builds sized tiles from adapter snapshots with status metadata", async () => {
+    const results = await fetchProtocolTvlResults();
+    const treemap = buildProtocolTvlTreemap(results);
+
+    assert.equal(treemap.metric, "tvl");
+    assert.ok(Number(treemap.value) > 0);
+    assert.ok((treemap.children?.length ?? 0) >= 4);
+
+    const stale = treemap.children?.find((child) => child.name === "LOBSTR");
+    assert.ok(stale);
+    assert.equal(stale?.meta?.adapterStatus, "stale");
+    assert.equal(stale?.meta?.adapterStatusLabel, "Stale");
+    assert.ok((stale?.meta?.tvlUsd ?? 0) > 0);
+    assert.ok(stale?.meta?.snapshotTime);
+  });
+});

--- a/lib/tvl/build-protocol-treemap.ts
+++ b/lib/tvl/build-protocol-treemap.ts
@@ -1,0 +1,95 @@
+import type { TvlAdapterResult } from "@/lib/tvl/adapter";
+import type { TreemapPayload, TreemapNode } from "@/lib/types";
+
+const STATUS_COLORS: Record<string, string> = {
+  complete: "#10B981",
+  partial: "#F59E0B",
+  stale: "#EF4444",
+  unsupported: "#6B7280",
+  failed: "#6B7280",
+};
+
+const USD_TVL_UNIT = {
+  kind: "asset" as const,
+  asset: { type: "issued" as const, code: "USD", issuer: "adapter" },
+};
+
+function sumUsd(result: TvlAdapterResult): number {
+  if (!("positions" in result)) return 0;
+  return result.positions.reduce(
+    (sum, position) => sum + Number(position.usdValue || 0),
+    0,
+  );
+}
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case "complete":
+      return "Complete";
+    case "partial":
+      return "Partial";
+    case "stale":
+      return "Stale";
+    case "unsupported":
+      return "Unsupported";
+    case "failed":
+      return "Failed";
+    default:
+      return status;
+  }
+}
+
+/**
+ * Build a Protocol TVL treemap from adapter results.
+ * Unsupported/failed adapters are omitted from tile sizing but kept out of
+ * the value sum so partial coverage stays visible via status metadata.
+ */
+export function buildProtocolTvlTreemap(
+  results: TvlAdapterResult[],
+): TreemapPayload<"tvl"> {
+  const usable = results.filter(
+    (result) =>
+      result.status === "complete" ||
+      result.status === "partial" ||
+      result.status === "stale",
+  );
+
+  const total = usable.reduce((sum, result) => sum + sumUsd(result), 0);
+
+  const children: TreemapNode<string>[] = usable
+    .map((result) => {
+      const tvlUsd = sumUsd(result);
+      const share = total > 0 ? (tvlUsd / total) * 100 : 0;
+      return {
+        id: result.protocol.toLowerCase(),
+        name: result.protocol,
+        value: String(tvlUsd),
+        color: STATUS_COLORS[result.status] ?? STATUS_COLORS.failed,
+        meta: {
+          type: "protocol" as const,
+          protocol: result.protocol,
+          share,
+          tvlUsd,
+          snapshotTime: result.snapshotTime,
+          adapterStatus: result.status,
+          adapterStatusLabel: statusLabel(result.status),
+          childCount: 0,
+        },
+      };
+    })
+    .sort((a, b) => Number(b.value) - Number(a.value));
+
+  return {
+    name: "Protocol TVL",
+    value: String(total),
+    metric: "tvl",
+    unit: USD_TVL_UNIT,
+    meta: {
+      type: "root",
+      share: 100,
+      tvlUsd: total,
+      childCount: children.length,
+    },
+    children,
+  };
+}

--- a/lib/tvl/protocol-registry.ts
+++ b/lib/tvl/protocol-registry.ts
@@ -1,0 +1,93 @@
+import type { ProtocolTvlAdapter, TvlAdapterResult } from "@/lib/tvl/adapter";
+import { ExampleTvlAdapter } from "@/lib/tvl/adapter";
+
+function hoursAgo(hours: number): string {
+  return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+}
+
+function completeResult(
+  protocol: string,
+  usdValue: string,
+  hoursSinceSnapshot: number,
+): TvlAdapterResult {
+  return {
+    protocol,
+    network: "stellar",
+    status: "complete",
+    methodologyVersion: "1.0.0",
+    snapshotTime: hoursAgo(hoursSinceSnapshot),
+    positions: [
+      {
+        canonicalAsset: "USD",
+        nativeAmount: usdValue,
+        usdValue,
+        priceProvenance: {
+          source: "fixture-adapter",
+          timestamp: hoursAgo(hoursSinceSnapshot),
+        },
+      },
+    ],
+  };
+}
+
+function staleResult(protocol: string, usdValue: string): TvlAdapterResult {
+  return {
+    protocol,
+    network: "stellar",
+    status: "stale",
+    methodologyVersion: "1.0.0",
+    snapshotTime: hoursAgo(30),
+    error: "Snapshot older than 24h",
+    positions: [
+      {
+        canonicalAsset: "USD",
+        nativeAmount: usdValue,
+        usdValue,
+        priceProvenance: {
+          source: "fixture-adapter",
+          timestamp: hoursAgo(30),
+        },
+      },
+    ],
+  };
+}
+
+function partialResult(protocol: string, usdValue: string): TvlAdapterResult {
+  return {
+    protocol,
+    network: "stellar",
+    status: "partial",
+    methodologyVersion: "1.0.0",
+    snapshotTime: hoursAgo(8),
+    error: "Missing secondary venue inventory",
+    positions: [
+      {
+        canonicalAsset: "USD",
+        nativeAmount: usdValue,
+        usdValue,
+        priceProvenance: {
+          source: "fixture-adapter",
+          timestamp: hoursAgo(8),
+        },
+      },
+    ],
+  };
+}
+
+/** Fixture-backed snapshots so Protocol TVL works without live venue APIs. */
+export const PROTOCOL_TVL_FIXTURE_RESULTS: TvlAdapterResult[] = [
+  completeResult("Soroswap", "15000000", 1),
+  completeResult("Circle", "500000000", 0.5),
+  partialResult("Kraken", "100000000"),
+  staleResult("LOBSTR", "50000000"),
+  completeResult("MoneyGram", "75000000", 0.25),
+];
+
+export const PROTOCOL_TVL_ADAPTERS: ProtocolTvlAdapter[] =
+  PROTOCOL_TVL_FIXTURE_RESULTS.map(
+    (result) => new ExampleTvlAdapter(result),
+  );
+
+export async function fetchProtocolTvlResults(): Promise<TvlAdapterResult[]> {
+  return Promise.all(PROTOCOL_TVL_ADAPTERS.map((adapter) => adapter.getTvl()));
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,7 +10,12 @@ export type MetricId =
   | "tvl";
 
 /** Internal selector values for the metrics currently backed by queries. */
-export type DashboardMetricId = "ops" | "xlm_volume" | "usdc" | "transactions";
+export type DashboardMetricId =
+  | "ops"
+  | "xlm_volume"
+  | "usdc"
+  | "transactions"
+  | "protocol_tvl";
 
 export type CountUnit =
   | { kind: "count"; subject: "operation" }
@@ -194,7 +199,8 @@ export type TreemapNodeType =
   | "category"
   | "entity"
   | "contract"
-  | "account";
+  | "account"
+  | "protocol";
 
 export interface EntityInfo {
   name: string;
@@ -306,6 +312,10 @@ export interface TreemapNodeMeta {
   txnCount?: number;
   xlmVolume?: number;
   usdcVolume?: number;
+  tvlUsd?: number;
+  snapshotTime?: string;
+  adapterStatus?: string;
+  adapterStatusLabel?: string;
   childCount?: number;
   eventType?: string;
   synthetic?: boolean;
@@ -361,6 +371,7 @@ export interface ActivityTreemaps {
   xlm_actors: TreemapPayload<"asset_volume">;
   usdc_events: TreemapPayload<"asset_volume">;
   usdc_actors: TreemapPayload<"asset_volume">;
+  protocol_tvl: TreemapPayload<"tvl">;
 }
 
 export interface ActivityResponseMetadata {


### PR DESCRIPTION
Closes #45

Recovers Protocol TVL after the Elvis fork head was wiped, using the typed TVL adapter contract:

- Add Protocol TVL to the treemap metric selector
- Build a USD protocol treemap from fixture-backed adapters
- Surface complete / partial / stale adapter status in tiles and details
- Keep category filters scoped to operation-based metrics

Assignee unchanged (`Dev-ElvisTobi`).