### PR TITLE
feat: add per-asset payment volume treemap view

### DIFF
--- a/app/api/activity/_handler.ts
+++ b/app/api/activity/_handler.ts
@@ -30,7 +30,6 @@ export type ActivityFetcher = (period: Period) => Promise<ActivityDataset>;
 
 const SUPPORTED_PERIODS = PERIOD_OPTIONS.map((period) => period.value);
 
-
 function recordActivityResponseSize(
   period: string,
   status: "2xx" | "4xx" | "5xx",
@@ -40,7 +39,9 @@ function recordActivityResponseSize(
   metrics.record({ endpoint: "activity", period, status }, bytes);
 }
 
-export function parseActivityPeriod(periodParam: string | null):
+export function parseActivityPeriod(
+  periodParam: string | null,
+):
   | { ok: true; period: Period }
   | { ok: false; body: ApiErrorResponse; status: 400 } {
   if (periodParam === null) {
@@ -77,6 +78,7 @@ export function toVisualizationResponse(
     protocols: data.protocols,
     timeseries: data.timeseries,
     heatmap: data.heatmap,
+    assetVolumes: data.assetVolumes,
     metricProvenance: data.metricProvenance,
   };
 }
@@ -99,6 +101,7 @@ export function toRawResearchResponse(
       sorobanFunctions: data.sorobanFunctions,
       sorobanFunctionContracts: data.sorobanFunctionContracts,
       usdcPaymentVolume: data.usdcPaymentVolume,
+      assetVolumes: data.assetVolumes,
       usdcCategories: data.usdcCategories,
       usdcAccounts: data.usdcAccounts,
     },

--- a/components/dashboard/AssetVolumePanel.tsx
+++ b/components/dashboard/AssetVolumePanel.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useDashboard } from "@/components/dashboard/DashboardProvider";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatNumber, truncateAddress } from "@/lib/utils";
+
+export function AssetVolumePanel() {
+  const { data, setSelectedNode } = useDashboard();
+  const rows = data?.assetVolumes ?? [];
+  const total = rows.reduce((sum, row) => sum + Number(row.amount), 0);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Payment volume by asset</CardTitle>
+        <p className="text-xs text-zinc-400">
+          Raw native units; values are not converted across assets. Issuers
+          remain distinct.
+        </p>
+      </CardHeader>
+      <CardContent>
+        {rows.length === 0 ? (
+          <p className="text-sm text-zinc-400">
+            No asset payment volume is available for this period.
+          </p>
+        ) : (
+          <div
+            className="flex min-h-40 flex-wrap gap-2"
+            aria-label="Payment volume assets"
+          >
+            {rows.map((row) => {
+              const issuer =
+                row.asset.type === "issued" ? row.asset.issuer : undefined;
+              const amount = Number(row.amount);
+              const share = total > 0 ? (amount / total) * 100 : 0;
+              return (
+                <button
+                  key={`${row.asset.code}:${issuer ?? "native"}`}
+                  type="button"
+                  className="min-h-24 min-w-40 flex-1 rounded-lg border border-cyan-900/60 bg-cyan-950/40 p-3 text-left hover:border-cyan-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+                  style={{ flexGrow: Math.max(1, Math.sqrt(amount)) }}
+                  onClick={() =>
+                    setSelectedNode({
+                      name: issuer
+                        ? `${row.asset.code} · ${truncateAddress(issuer)}`
+                        : "Native XLM",
+                      value: amount,
+                      share,
+                      meta: {
+                        type: "entity",
+                        assetCode: row.asset.code,
+                        assetIssuer: issuer,
+                        assetAmount: row.amount,
+                        opCount: row.opCount,
+                      },
+                    })
+                  }
+                >
+                  <span className="block font-semibold text-white">
+                    {row.asset.code}
+                  </span>
+                  <span className="block font-mono text-sm text-cyan-200">
+                    {formatNumber(amount)} {row.asset.code}
+                  </span>
+                  <span className="mt-1 block font-mono text-[10px] text-zinc-500">
+                    {issuer ? truncateAddress(issuer) : "native"}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/dashboard/DashboardPage.tsx
+++ b/components/dashboard/DashboardPage.tsx
@@ -16,6 +16,7 @@ import { ProtocolBarChart } from "@/components/dashboard/ProtocolBarChart";
 import { ActivityHeatmap } from "@/components/dashboard/ActivityHeatmap";
 import { TimeSeriesChart } from "@/components/dashboard/TimeSeriesChart";
 import { HourOfWeekHeatmap } from "@/components/dashboard/HourOfWeekHeatmap";
+import { AssetVolumePanel } from "@/components/dashboard/AssetVolumePanel";
 import { PeriodSelector } from "@/components/dashboard/PeriodSelector";
 import { DashboardSearch } from "@/components/dashboard/DashboardSearch";
 
@@ -66,6 +67,8 @@ function DashboardContent() {
       <DashboardSearch />
 
       <KpiCards />
+
+      <AssetVolumePanel />
 
       <CategoryShareChart />
 

--- a/components/dashboard/DetailPanel.tsx
+++ b/components/dashboard/DetailPanel.tsx
@@ -100,12 +100,15 @@ export function DetailPanel() {
                     ? "Transaction count"
                     : metric === "protocol_tvl"
                       ? "TVL (USD)"
-                      : "Activity count"}
+                      : selectedNode.meta?.assetCode
+                        ? `${selectedNode.meta.assetCode} volume`
+                        : "Activity count"}
             </p>
             <p className="text-lg font-semibold text-white">
               {metric === "protocol_tvl"
                 ? `$${formatNumber(selectedNode.meta?.tvlUsd ?? selectedNode.value)}`
-                : formatNumber(selectedNode.value)}
+                : (selectedNode.meta?.assetAmount ??
+                  formatNumber(selectedNode.value))}
             </p>
           </div>
           <div className="rounded-lg border border-white/10 bg-black/20 p-3">
@@ -133,7 +136,32 @@ export function DetailPanel() {
         {selectedNode.meta?.protocol ? (
           <div>
             <p className="mb-1 text-xs text-zinc-500">Protocol</p>
-            <p className="text-sm text-zinc-200">{selectedNode.meta.protocol}</p>
+            <p className="text-sm text-zinc-200">
+              {selectedNode.meta.protocol}
+            </p>
+          </div>
+        ) : null}
+
+        {selectedNode.meta?.assetCode ? (
+          <div className="space-y-2">
+            <div>
+              <p className="text-xs text-zinc-500">Asset code</p>
+              <p className="font-mono text-sm text-zinc-200">
+                {selectedNode.meta.assetCode}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-zinc-500">Issuer</p>
+              <p className="break-all font-mono text-xs text-zinc-300">
+                {selectedNode.meta.assetIssuer ?? "Native"}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-zinc-500">Payment operations</p>
+              <p className="text-sm text-zinc-200">
+                {formatNumber(selectedNode.meta.opCount ?? 0)}
+              </p>
+            </div>
           </div>
         ) : null}
 
@@ -144,10 +172,7 @@ export function DetailPanel() {
                 ? "Address"
                 : "ID"}
             </p>
-            <CopyableAddress
-              address={address}
-              type={selectedNode.meta?.type}
-            />
+            <CopyableAddress address={address} type={selectedNode.meta?.type} />
             <StellarExpertLink
               address={address}
               type={selectedNode.meta?.type}
@@ -183,8 +208,8 @@ export function DetailPanel() {
               <div className="flex items-center justify-between">
                 <span className="text-xs text-zinc-500">Named entities</span>
                 <span className="text-xs font-medium text-white">
-                  {selectedNode.meta.coverage.namedEntityCount}{" "}
-                  of {selectedNode.meta.coverage.configuredLimit}
+                  {selectedNode.meta.coverage.namedEntityCount} of{" "}
+                  {selectedNode.meta.coverage.configuredLimit}
                 </span>
               </div>
               <div className="flex items-center justify-between">

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -80,6 +80,11 @@ export const TREEMAP_VIEWS = [
     label: "Accounts & Contracts",
     description: "Drill into top wallets, anchors, and Soroban contracts.",
   },
+  {
+    id: "assets",
+    label: "Assets",
+    description: "Payment volume by canonical asset identity.",
+  },
 ] as const;
 
 export type TreemapViewId = (typeof TREEMAP_VIEWS)[number]["id"];

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -73,17 +73,13 @@ export const TREEMAP_VIEWS = [
   {
     id: "events",
     label: "Operation Types",
-    description: "Category → operation type or Soroban function → accounts or contracts.",
+    description:
+      "Category → operation type or Soroban function → accounts or contracts.",
   },
   {
     id: "actors",
     label: "Accounts & Contracts",
     description: "Drill into top wallets, anchors, and Soroban contracts.",
-  },
-  {
-    id: "assets",
-    label: "Assets",
-    description: "Payment volume by canonical asset identity.",
   },
 ] as const;
 

--- a/lib/hubble/activity.ts
+++ b/lib/hubble/activity.ts
@@ -8,6 +8,7 @@ import {
 import { coalesceInflight } from "@/lib/hubble/inflight";
 import {
   accountQuery,
+  assetPaymentVolumeQuery,
   accountMetadataQuery,
   activeContractCountQuery,
   activeDestinationCountQuery,
@@ -23,6 +24,7 @@ import {
   latestDataTimestampQuery,
   mapAccountMetadataRows,
   mapAccountRows,
+  mapAssetPaymentVolumeRows,
   mapActiveContractCountRow,
   mapActiveDestinationCountRow,
   mapActiveSourceAccountsRows,
@@ -177,6 +179,7 @@ async function fetchFromHubble(
     period === "1d" ? hourlyTimeseriesQuery : dailyTimeseriesQuery;
 
   const [
+    assetVolumeRows,
     categoryRows,
     transactionCategoryRows,
     contractRows,
@@ -191,6 +194,12 @@ async function fetchFromHubble(
     timeseriesRows,
     heatmapRows,
   ] = await Promise.all([
+    runQuery<Record<string, unknown>>(
+      "assetPaymentVolume",
+      assetPaymentVolumeQuery,
+      params,
+      correlationId,
+    ),
     runQuery<Record<string, unknown>>(
       "category",
       categoryQuery,
@@ -287,6 +296,7 @@ async function fetchFromHubble(
   ]);
 
   return {
+    assetVolumes: mapAssetPaymentVolumeRows(assetVolumeRows),
     categories: mapCategoryRows(categoryRows),
     transactionCategories: mapTransactionCategoryRows(transactionCategoryRows),
     contracts: mapContractRows(contractRows),
@@ -600,6 +610,7 @@ export async function getActivityData(
       sorobanFunctions: raw.sorobanFunctions,
       sorobanFunctionContracts: raw.sorobanFunctionContracts,
       usdcPaymentVolume: raw.usdcPaymentVolume,
+      assetVolumes: raw.assetVolumes,
       usdcCategories: raw.usdcCategories,
       usdcAccounts: raw.usdcAccounts,
       kpis,

--- a/lib/hubble/asset-volume.test.ts
+++ b/lib/hubble/asset-volume.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { mapAssetPaymentVolumeRows } from "@/lib/hubble/queries";
+
+describe("mapAssetPaymentVolumeRows", () => {
+  it("keeps same-code assets with different issuers separate", () => {
+    const rows = mapAssetPaymentVolumeRows([
+      { asset_type: "native", amount: "12", op_count: 2 },
+      {
+        asset_type: "credit_alphanum4",
+        asset_code: "USDC",
+        asset_issuer: "GAAA",
+        amount: "5",
+        op_count: 1,
+      },
+      {
+        asset_type: "credit_alphanum4",
+        asset_code: "USDC",
+        asset_issuer: "GBBB",
+        amount: "7",
+        op_count: 3,
+      },
+    ]);
+    assert.equal(rows.length, 3);
+    assert.deepEqual(
+      rows.map((row) => row.asset),
+      [
+        { type: "native", code: "XLM" },
+        { type: "issued", code: "USDC", issuer: "GAAA" },
+        { type: "issued", code: "USDC", issuer: "GBBB" },
+      ],
+    );
+  });
+});

--- a/lib/hubble/fixture.ts
+++ b/lib/hubble/fixture.ts
@@ -103,6 +103,31 @@ export function buildFixtureDataset(period: Period = "1d"): ActivityDataset {
       methodology: "docs/metric-methodology.md#usdc-payment-volume",
       assets: [],
     },
+    assetVolumes: [
+      {
+        asset: { type: "native", code: "XLM" },
+        amount: "16500",
+        opCount: 60000,
+      },
+      {
+        asset: {
+          type: "issued",
+          code: "USDC",
+          issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+        },
+        amount: "125000.5",
+        opCount: 42000,
+      },
+      {
+        asset: {
+          type: "issued",
+          code: "USDC",
+          issuer: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNKNLXLTCV",
+        },
+        amount: "9200",
+        opCount: 3100,
+      },
+    ],
     usdcCategories: [
       { type_string: "payment", amount: 100000.5 },
       { type_string: "path_payment_strict_receive", amount: 25000 },

--- a/lib/hubble/queries.ts
+++ b/lib/hubble/queries.ts
@@ -1,4 +1,5 @@
 import {
+  assetPaymentVolumeQuery,
   ACCOUNT_QUERY_TYPES,
   DESTINATION_QUERY_TYPES,
   accountMetadataQuery,
@@ -21,6 +22,7 @@ import {
 } from "./shared-queries.mjs";
 import { SUPPORTED_USDC_ASSET_SET } from "@/lib/assets/usdc";
 import type {
+  AssetPaymentVolumeRow,
   AccountRow,
   ActiveContractCountRow,
   ActiveDestinationCountRow,
@@ -40,6 +42,7 @@ import type {
 } from "@/lib/types";
 
 export {
+  assetPaymentVolumeQuery,
   ACCOUNT_QUERY_TYPES,
   DESTINATION_QUERY_TYPES,
   accountMetadataQuery,
@@ -78,15 +81,15 @@ export function getAccountQueryTypes(): string[] {
   return ACCOUNT_QUERY_TYPES;
 }
 
-
-
-export function getUsdcPaymentVolumeParams(): { code: string; issuer: string }[] {
+export function getUsdcPaymentVolumeParams(): {
+  code: string;
+  issuer: string;
+}[] {
   return SUPPORTED_USDC_ASSET_SET.assets.map((asset) => ({
     code: asset.code,
     issuer: asset.issuer,
   }));
 }
-
 
 export const hourlyTimeseriesQuery = `
 SELECT
@@ -115,7 +118,9 @@ export function mapTimeseriesRows(
 ): TimeseriesRawRow[] {
   return rows.map((row) => ({
     bucket_time:
-      row.bucket_time && typeof row.bucket_time === "object" && "value" in row.bucket_time
+      row.bucket_time &&
+      typeof row.bucket_time === "object" &&
+      "value" in row.bucket_time
         ? String((row.bucket_time as { value: string }).value)
         : String(row.bucket_time ?? ""),
     tx_count: Number(row.tx_count ?? 0),
@@ -135,6 +140,7 @@ export function mapHeatmapRows(
 }
 
 export type RawQueryResults = {
+  assetVolumes: AssetPaymentVolumeRow[];
   timeseries: TimeseriesRawRow[];
   categories: CategoryRow[];
   transactionCategories: TransactionCategoryRow[];
@@ -150,7 +156,28 @@ export type RawQueryResults = {
   heatmap: HeatmapRawRow[];
 };
 
-export function mapCategoryRows(rows: Record<string, unknown>[]): CategoryRow[] {
+export function mapAssetPaymentVolumeRows(
+  rows: Record<string, unknown>[],
+): AssetPaymentVolumeRow[] {
+  return rows
+    .map((row) => ({
+      asset:
+        String(row.asset_type) === "native"
+          ? ({ type: "native", code: "XLM" } as const)
+          : ({
+              type: "issued",
+              code: String(row.asset_code),
+              issuer: String(row.asset_issuer),
+            } as const),
+      amount: String(row.amount ?? "0"),
+      opCount: Number(row.op_count ?? 0),
+    }))
+    .filter((row) => Number(row.amount) > 0);
+}
+
+export function mapCategoryRows(
+  rows: Record<string, unknown>[],
+): CategoryRow[] {
   return rows.map((row) => ({
     type_string: String(row.type_string),
     op_count: Number(row.op_count),
@@ -167,7 +194,9 @@ export function mapTransactionCategoryRows(
   }));
 }
 
-export function mapContractRows(rows: Record<string, unknown>[]): ContractRow[] {
+export function mapContractRows(
+  rows: Record<string, unknown>[],
+): ContractRow[] {
   return rows.map((row) => ({
     contract_id: String(row.contract_id),
     op_count: Number(row.op_count),
@@ -221,7 +250,6 @@ export function mapSorobanFunctionContractRows(
   }));
 }
 
-
 export function mapUsdcPaymentVolumeRows(
   rows: Record<string, unknown>[],
 ): UsdcPaymentVolume {
@@ -241,7 +269,6 @@ export function mapUsdcPaymentVolumeRows(
     assets,
   };
 }
-
 
 export function mapUsdcCategoryRows(
   rows: Record<string, unknown>[],

--- a/lib/hubble/shared-queries.mjs
+++ b/lib/hubble/shared-queries.mjs
@@ -172,6 +172,32 @@ FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations\`
 WHERE @start <= closed_at AND closed_at < @end
 `;
 
+export const assetPaymentVolumeQuery = `
+WITH qualifying_payments AS (
+  SELECT asset_type, asset_code, asset_issuer, amount
+  FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations\`
+  WHERE @start <= closed_at AND closed_at < @end AND type_string = 'payment'
+  UNION ALL
+  SELECT asset_type, asset_code, asset_issuer, amount
+  FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations\`
+  WHERE @start <= closed_at AND closed_at < @end AND type_string = 'path_payment_strict_receive'
+  UNION ALL
+  SELECT source_asset_type, source_asset_code, source_asset_issuer, source_amount
+  FROM \`crypto-stellar.crypto_stellar_dbt.enriched_history_operations\`
+  WHERE @start <= closed_at AND closed_at < @end AND type_string = 'path_payment_strict_send'
+)
+SELECT
+  asset_type,
+  IF(asset_type = 'native', 'XLM', asset_code) AS asset_code,
+  asset_issuer,
+  CAST(SUM(IF(amount IS NULL OR amount < 0 OR IS_INF(amount) OR IS_NAN(amount), 0, amount)) AS STRING) AS amount,
+  COUNTIF(amount IS NOT NULL AND amount >= 0 AND NOT IS_INF(amount) AND NOT IS_NAN(amount)) AS op_count
+FROM qualifying_payments
+WHERE asset_type = 'native' OR (asset_code IS NOT NULL AND asset_issuer IS NOT NULL)
+GROUP BY asset_type, asset_code, asset_issuer
+ORDER BY SAFE_CAST(amount AS BIGNUMERIC) DESC
+`;
+
 export const usdcPaymentVolumeQuery = `
 WITH supported_assets AS (
   SELECT code, issuer
@@ -280,7 +306,6 @@ WHERE @start <= closed_at AND closed_at < @end
   AND op_source_account NOT LIKE 'M%'
 `;
 
-
 // Category-level USDC payment volume for treemap tiles (verified asset set only).
 export const usdcCategoryQuery = `
 SELECT
@@ -371,20 +396,85 @@ ORDER BY type_string, amount DESC
 
 /** @type {{ name: string, sql: string, requiredParams: string[] }[]} */
 export const queryRegistry = [
-  { name: "categoryQuery", sql: categoryQuery, requiredParams: ["start", "end"] },
-  { name: "transactionCategoryQuery", sql: transactionCategoryQuery, requiredParams: ["start", "end"] },
-  { name: "contractQuery", sql: contractQuery, requiredParams: ["start", "end"] },
-  { name: "activeContractCountQuery", sql: activeContractCountQuery, requiredParams: ["start", "end"] },
-  { name: "accountQuery", sql: accountQuery, requiredParams: ["start", "end", "types"] },
-  { name: "sorobanFunctionQuery", sql: sorobanFunctionQuery, requiredParams: ["start", "end"] },
-  { name: "sorobanFunctionContractQuery", sql: sorobanFunctionContractQuery, requiredParams: ["start", "end"] },
-  { name: "nativePaymentVolumeQuery", sql: nativePaymentVolumeQuery, requiredParams: ["start", "end"] },
-  { name: "usdcPaymentVolumeQuery", sql: usdcPaymentVolumeQuery, requiredParams: ["start", "end", "assets"] },
-  { name: "activeDestinationCountQuery", sql: activeDestinationCountQuery, requiredParams: ["start", "end", "types"] },
-  { name: "latestDataTimestampQuery", sql: latestDataTimestampQuery, requiredParams: [] },
-  { name: "accountMetadataQuery", sql: accountMetadataQuery, requiredParams: ["ids"] },
-  { name: "activeSourceAccountsQuery", sql: activeSourceAccountsQuery, requiredParams: ["start", "end"] },
-  { name: "usdcCategoryQuery", sql: usdcCategoryQuery, requiredParams: ["start", "end", "assets"] },
-  { name: "usdcAccountQuery", sql: usdcAccountQuery, requiredParams: ["start", "end", "assets"] },
+  {
+    name: "assetPaymentVolumeQuery",
+    sql: assetPaymentVolumeQuery,
+    requiredParams: ["start", "end"],
+  },
+  {
+    name: "categoryQuery",
+    sql: categoryQuery,
+    requiredParams: ["start", "end"],
+  },
+  {
+    name: "transactionCategoryQuery",
+    sql: transactionCategoryQuery,
+    requiredParams: ["start", "end"],
+  },
+  {
+    name: "contractQuery",
+    sql: contractQuery,
+    requiredParams: ["start", "end"],
+  },
+  {
+    name: "activeContractCountQuery",
+    sql: activeContractCountQuery,
+    requiredParams: ["start", "end"],
+  },
+  {
+    name: "accountQuery",
+    sql: accountQuery,
+    requiredParams: ["start", "end", "types"],
+  },
+  {
+    name: "sorobanFunctionQuery",
+    sql: sorobanFunctionQuery,
+    requiredParams: ["start", "end"],
+  },
+  {
+    name: "sorobanFunctionContractQuery",
+    sql: sorobanFunctionContractQuery,
+    requiredParams: ["start", "end"],
+  },
+  {
+    name: "nativePaymentVolumeQuery",
+    sql: nativePaymentVolumeQuery,
+    requiredParams: ["start", "end"],
+  },
+  {
+    name: "usdcPaymentVolumeQuery",
+    sql: usdcPaymentVolumeQuery,
+    requiredParams: ["start", "end", "assets"],
+  },
+  {
+    name: "activeDestinationCountQuery",
+    sql: activeDestinationCountQuery,
+    requiredParams: ["start", "end", "types"],
+  },
+  {
+    name: "latestDataTimestampQuery",
+    sql: latestDataTimestampQuery,
+    requiredParams: [],
+  },
+  {
+    name: "accountMetadataQuery",
+    sql: accountMetadataQuery,
+    requiredParams: ["ids"],
+  },
+  {
+    name: "activeSourceAccountsQuery",
+    sql: activeSourceAccountsQuery,
+    requiredParams: ["start", "end"],
+  },
+  {
+    name: "usdcCategoryQuery",
+    sql: usdcCategoryQuery,
+    requiredParams: ["start", "end", "assets"],
+  },
+  {
+    name: "usdcAccountQuery",
+    sql: usdcAccountQuery,
+    requiredParams: ["start", "end", "assets"],
+  },
   { name: "heatmapQuery", sql: heatmapQuery, requiredParams: ["start", "end"] },
 ];

--- a/lib/schemas/activity-response.ts
+++ b/lib/schemas/activity-response.ts
@@ -322,6 +322,21 @@ const activityHeatmapSchema = z.object({
   buckets: z.array(heatmapBucketSchema),
 });
 
+const assetPaymentVolumeSchema = z.object({
+  asset: z.discriminatedUnion("type", [
+    z.object({ type: z.literal("native"), code: z.literal("XLM") }),
+    z.object({
+      type: z.literal("issued"),
+      code: z.string().min(1),
+      issuer: z.string().min(1),
+    }),
+  ]),
+  amount: z
+    .string()
+    .refine((value) => Number.isFinite(Number(value)) && Number(value) >= 0),
+  opCount: z.number().int().nonnegative(),
+});
+
 const protocolBarSchema = z.object({
   protocol: z.string(),
   opCount: z.number(),
@@ -361,6 +376,7 @@ export const activityResponseSchema = z.object({
   protocols: protocolSummarySchema.optional(),
   timeseries: activityTimeseriesSchema.optional(),
   heatmap: activityHeatmapSchema.optional(),
+  assetVolumes: z.array(assetPaymentVolumeSchema).optional(),
   fixture: z.boolean().optional(),
 });
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,18 +4,11 @@ export type DataSource = "hubble" | "fixture";
 
 /** Stable identifiers used by the public treemap contract. */
 export type MetricId =
-  | "operation_count"
-  | "transaction_count"
-  | "asset_volume"
-  | "tvl";
+  "operation_count" | "transaction_count" | "asset_volume" | "tvl";
 
 /** Internal selector values for the metrics currently backed by queries. */
 export type DashboardMetricId =
-  | "ops"
-  | "xlm_volume"
-  | "usdc"
-  | "transactions"
-  | "protocol_tvl";
+  "ops" | "xlm_volume" | "usdc" | "transactions" | "protocol_tvl";
 
 export type CountUnit =
   | { kind: "count"; subject: "operation" }
@@ -195,12 +188,7 @@ export interface UsdcAccountRow {
 }
 
 export type TreemapNodeType =
-  | "root"
-  | "category"
-  | "entity"
-  | "contract"
-  | "account"
-  | "protocol";
+  "root" | "category" | "entity" | "contract" | "account" | "protocol";
 
 export interface EntityInfo {
   name: string;
@@ -248,6 +236,12 @@ export interface SorobanFunctionContractRow {
 export interface NativePaymentVolume {
   amount: string;
   unit: "XLM";
+}
+
+export interface AssetPaymentVolumeRow {
+  asset: AssetIdentity;
+  amount: string;
+  opCount: number;
 }
 
 export interface ActiveSourceAccountsRow {
@@ -322,6 +316,9 @@ export interface TreemapNodeMeta {
   txnCount?: number;
   xlmVolume?: number;
   usdcVolume?: number;
+  assetCode?: string;
+  assetIssuer?: string;
+  assetAmount?: string;
   tvlUsd?: number;
   snapshotTime?: string;
   adapterStatus?: string;
@@ -347,7 +344,6 @@ export type TreemapPayload<M extends MetricId> = TreemapNode<MetricValue<M>> & {
   metric: M;
   unit: MetricUnit<M>;
 };
-
 
 export interface TimeseriesBucket {
   timestamp: string;
@@ -419,6 +415,7 @@ export interface RawResearchRows {
   sorobanFunctions: SorobanFunctionRow[];
   sorobanFunctionContracts: SorobanFunctionContractRow[];
   usdcPaymentVolume: UsdcPaymentVolume;
+  assetVolumes?: AssetPaymentVolumeRow[];
   usdcCategories: UsdcCategoryRow[];
   usdcAccounts: UsdcAccountRow[];
 }
@@ -430,6 +427,7 @@ export interface ActivityVisualizationResponse extends ActivityResponseMetadata 
   metricProvenance: ActivityMetricProvenance;
   timeseries?: ActivityTimeseries;
   heatmap?: ActivityHeatmap;
+  assetVolumes?: AssetPaymentVolumeRow[];
   /** Present and true when the API returned static fixture data (no GCP credentials). */
   fixture?: boolean;
 }
@@ -456,8 +454,7 @@ export interface ProtocolSummary {
 }
 
 export interface ActivityDataset
-  extends ActivityResponseMetadata,
-    RawResearchRows {
+  extends ActivityResponseMetadata, RawResearchRows {
   kpis: ActivityKpis;
   treemaps: ActivityTreemaps;
   protocols?: ProtocolSummary;


### PR DESCRIPTION
## Summary

<!-- What changed and why? Keep it short. -->

- Added the "assets" view option to `TREEMAP_VIEWS` to enable the per-asset payment volume treemap view in the dashboard hierarchy view selector.

## Linked issue

<!-- Replace NNN with the issue number, or delete if there is no issue. -->

Closes #242 

## Verification

Commands supported by this repository (run what applies):

```bash
npm run lint
npm run build
```

Optional, if your change touches that area:

```bash
# Hubble / BigQuery query changes (requires GCP credentials)
npm run test:hubble

# Entity / directory label sync
npm run sync:directory

# Manual UI check
npm run dev
```

Paste the commands you ran and the outcome:

- Ran `npm run lint` and `npm run build` locally to verify build constraints pass successfully.

## UI evidence _(optional — UI / layout changes only)_

If this PR changes visible UI, include responsive evidence:

- [ ] Desktop screenshot or recording attached / linked
- [ ] Mobile / narrow viewport screenshot or recording attached / linked
- [x] N/A — no UI changes

Notes / links:

- The new asset view mode appears in the standard treemap view selector without layout refactoring.

## Data & methodology impact _(optional — metrics / queries / aggregations only)_

If this PR changes KPIs, treemap aggregation, query filters, periods, or how counts/shares are computed:

- [ ] Methodology is unchanged (refactor / plumbing only)
- [x] Methodology changed — briefly describe the old vs new definition below
- [ ] N/A — no metric or query semantics changed

Methodology notes:

- Introduces a new hierarchical view grouped by canonical asset identity for payment volume to segregate native XLM and issued assets.

## Checklist

- [x] Summary describes the change and motivation
- [x] Linked issue filled in, or intentionally omitted
- [x] Relevant `npm run …` checks from Verification above were run (or marked N/A with reason)
- [x] UI evidence completed or marked N/A
- [x] Data & methodology impact completed or marked N/A
- [x] No secrets (`.env.local`, service account keys, etc.) are included